### PR TITLE
fix: 修复外接显示器时灵动岛位置偏移问题

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2495,6 +2495,39 @@ async fn remove_marketplace_source_cmd(id: String) -> Result<(), String> {
     skills::registry::remove_marketplace_source(&id)
 }
 
+// ── Display reconfiguration handler ──────────────────────────────
+#[cfg(target_os = "macos")]
+#[link(name = "CoreGraphics", kind = "framework")]
+extern "C" {
+    fn CGDisplayRegisterReconfigurationCallback(
+        callback: unsafe extern "C" fn(u32, u32, *mut std::ffi::c_void),
+        user_info: *mut std::ffi::c_void,
+    ) -> i32;
+}
+
+#[cfg(target_os = "macos")]
+static DISPLAY_RECONFIG_APP_HANDLE: OnceLock<tauri::AppHandle> = OnceLock::new();
+
+#[cfg(target_os = "macos")]
+unsafe extern "C" fn display_reconfig_callback(_display: u32, _flags: u32, _user_info: *mut std::ffi::c_void) {
+    // The callback fires before and after reconfiguration.
+    // Only reposition after the change settles.
+    if _flags & 1 != 0 {
+        return; // kCGDisplayBeginConfigurationFlag — skip, wait for completion callback
+    }
+    if let Some(handle) = DISPLAY_RECONFIG_APP_HANDLE.get() {
+        let handle = handle.clone();
+        // Delay briefly so macOS finishes updating internal display state
+        std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(600));
+            let h = handle.clone();
+            let _ = handle.run_on_main_thread(move || {
+                let _ = reposition_notch_to_display(&h, None, None);
+            });
+        });
+    }
+}
+
 // ── Opacity helpers ─────────────────────────────────────────────
 // macOS breaks transparent window compositing after a hide()/show() cycle,
 // so we manage visibility via opacity instead.
@@ -3195,11 +3228,14 @@ pub fn run() {
                     .or_else(|| window.primary_monitor().ok().flatten());
 
                 if let Some(monitor) = monitor {
-                    let screen_width = monitor.size().width as f64 / monitor.scale_factor();
+                    let scale = monitor.scale_factor();
+                    let screen_width = monitor.size().width as f64 / scale;
+                    let monitor_x = monitor.position().x as f64 / scale;
+                    let monitor_y = monitor.position().y as f64 / scale;
                     let window_width = 420.0; // 400 panel + 20 shadow padding
-                    let x = (screen_width - window_width) / 2.0;
+                    let x = monitor_x + (screen_width - window_width) / 2.0;
                     let _ = window.set_position(tauri::Position::Logical(
-                        tauri::LogicalPosition::new(x, 0.0),
+                        tauri::LogicalPosition::new(x, monitor_y),
                     ));
                 }
 
@@ -3211,6 +3247,18 @@ pub fn run() {
 
                 // Keep the island above the menu bar and present in fullscreen Spaces.
                 apply_notch_window_for_spaces(&window);
+
+                // Reposition the island when display configuration changes (e.g. external monitor connected/disconnected).
+                #[cfg(target_os = "macos")]
+                {
+                    let _ = DISPLAY_RECONFIG_APP_HANDLE.set(app.handle().clone());
+                    unsafe {
+                        CGDisplayRegisterReconfigurationCallback(
+                            display_reconfig_callback,
+                            std::ptr::null_mut(),
+                        );
+                    }
+                }
             }
 
             // Ensure settings window is hidden on startup


### PR DESCRIPTION
## 问题

Fixes #5 — 连接外接显示器后，AgentBro 灵动岛在主显示屏上的位置发生偏移。

## 根因

灵动岛定位逻辑存在两个问题：

1. **启动定位代码硬编码了 `y=0`**，且未使用 `monitor.position()` 偏移量。多显示器场景下，如果 `current_monitor()` 返回非主屏，x 居中会按错误屏幕宽度计算，y 会钉在全局坐标原点而非目标屏幕顶部。

2. **缺少显示器配置变更监听**。灵动岛只在启动时定位一次，热插拔显示器时不会重新定位，macOS 调整窗口坐标后导致位置偏移。

## 改动

`src-tauri/src/lib.rs`：

1. **启动定位（行 ~3228）**：从 `monitor.position()` 计算 `monitor_x` / `monitor_y`，与 `notch_window_geometry()` 保持一致。

2. **显示器变更回调（行 ~2498）**：注册 `CGDisplayRegisterReconfigurationCallback`，在显示器配置完成变更后延迟 600ms，然后在主线程调用 `reposition_notch_to_display` 恢复正确位置。

## 测试

- [ ] 单屏启动 — 灵动岛在主屏顶部居中
- [ ] 连接外接显示器 — 灵动岛位置保持正确
- [ ] 断开外接显示器 — 灵动岛位置保持正确
- [ ] 灵动岛模式：位置在显示器切换后保留
- [ ] 宠物模式：位置在显示器切换后保留
- [ ] 横向拖拽偏移：显示器切换后保留