### PR TITLE
fix: resolve CLI PATH detection, hook events, and add hook diagnostics

### DIFF
--- a/src-tauri/src/agents/antigravity.rs
+++ b/src-tauri/src/agents/antigravity.rs
@@ -95,7 +95,18 @@ impl AgentAdapter for AntiGravityAdapter {
                 terminal: "".to_string(),
                 agent_type: "antigravity".to_string(),
             }),
-            "session_end" | "Stop" => Ok(AgentEvent::SessionEnd { session_id }),
+            "session_end" => Ok(AgentEvent::SessionEnd { session_id }),
+            "Stop" => Ok(AgentEvent::AssistantResponseComplete {
+                session_id,
+                text: raw
+                    .get("summary")
+                    .or_else(|| raw.get("last_assistant_message"))
+                    .or_else(|| raw.get("message"))
+                    .and_then(|v| v.as_str())
+                    .filter(|v| !v.trim().is_empty())
+                    .unwrap_or("Task completed")
+                    .to_string(),
+            }),
             _ => Ok(AgentEvent::Processing {
                 session_id,
                 description: format!("Event: {}", event),

--- a/src-tauri/src/agents/claude_code.rs
+++ b/src-tauri/src/agents/claude_code.rs
@@ -41,20 +41,7 @@ fn config_dir_from_env(get: impl Fn(&str) -> Option<String>) -> Option<PathBuf> 
 }
 
 fn config_dir_from_login_shell() -> Option<PathBuf> {
-    let shell = std::env::var("SHELL")
-        .ok()
-        .filter(|value| !value.trim().is_empty())
-        .unwrap_or_else(|| "/bin/zsh".to_string());
-    let output = std::process::Command::new(shell)
-        .args(["-lc", "printf '%s' \"${CLAUDE_CONFIG_DIR:-}\""])
-        .stdin(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .output()
-        .ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let value = super::executable::login_shell_var("CLAUDE_CONFIG_DIR")?;
     config_dir_from_env(|_| Some(value.clone()))
 }
 

--- a/src-tauri/src/agents/claude_code.rs
+++ b/src-tauri/src/agents/claude_code.rs
@@ -1053,10 +1053,10 @@ pub fn send_message_to_terminal(
         std::thread::sleep(std::time::Duration::from_millis(200));
     }
 
-    if terminal_app.eq_ignore_ascii_case("wave") {
-        if send_message_via_wave_rpc(&terminal_env, message).is_ok() {
-            return Ok(());
-        }
+    if terminal_app.eq_ignore_ascii_case("wave")
+        && send_message_via_wave_rpc(&terminal_env, message).is_ok()
+    {
+        return Ok(());
     }
 
     run_osascript(&build_system_events_paste_script(message))

--- a/src-tauri/src/agents/codebuddycn.rs
+++ b/src-tauri/src/agents/codebuddycn.rs
@@ -100,7 +100,18 @@ impl AgentAdapter for CodeBuddyCNAdapter {
                 terminal: "".to_string(),
                 agent_type: "codebuddycn".to_string(),
             }),
-            "session_end" | "Stop" => Ok(AgentEvent::SessionEnd { session_id }),
+            "session_end" => Ok(AgentEvent::SessionEnd { session_id }),
+            "Stop" => Ok(AgentEvent::AssistantResponseComplete {
+                session_id,
+                text: raw
+                    .get("summary")
+                    .or_else(|| raw.get("last_assistant_message"))
+                    .or_else(|| raw.get("message"))
+                    .and_then(|v| v.as_str())
+                    .filter(|v| !v.trim().is_empty())
+                    .unwrap_or("Task completed")
+                    .to_string(),
+            }),
             _ => Ok(AgentEvent::Processing {
                 session_id,
                 description: format!("Event: {}", event),

--- a/src-tauri/src/agents/cursor.rs
+++ b/src-tauri/src/agents/cursor.rs
@@ -103,7 +103,18 @@ impl AgentAdapter for CursorAdapter {
                     .to_string(),
                 agent_type: "cursor".to_string(),
             }),
-            "session_end" | "Stop" => Ok(AgentEvent::SessionEnd { session_id }),
+            "session_end" => Ok(AgentEvent::SessionEnd { session_id }),
+            "Stop" => Ok(AgentEvent::AssistantResponseComplete {
+                session_id,
+                text: raw
+                    .get("summary")
+                    .or_else(|| raw.get("last_assistant_message"))
+                    .or_else(|| raw.get("message"))
+                    .and_then(|v| v.as_str())
+                    .filter(|v| !v.trim().is_empty())
+                    .unwrap_or("Task completed")
+                    .to_string(),
+            }),
             _ => Ok(AgentEvent::Processing {
                 session_id,
                 description: format!("Event: {}", event),

--- a/src-tauri/src/agents/cursor_cli.rs
+++ b/src-tauri/src/agents/cursor_cli.rs
@@ -103,7 +103,18 @@ impl AgentAdapter for CursorCliAdapter {
                     .to_string(),
                 agent_type: "cursor-cli".to_string(),
             }),
-            "session_end" | "Stop" => Ok(AgentEvent::SessionEnd { session_id }),
+            "session_end" => Ok(AgentEvent::SessionEnd { session_id }),
+            "Stop" => Ok(AgentEvent::AssistantResponseComplete {
+                session_id,
+                text: raw
+                    .get("summary")
+                    .or_else(|| raw.get("last_assistant_message"))
+                    .or_else(|| raw.get("message"))
+                    .and_then(|v| v.as_str())
+                    .filter(|v| !v.trim().is_empty())
+                    .unwrap_or("Task completed")
+                    .to_string(),
+            }),
             _ => Ok(AgentEvent::Processing {
                 session_id,
                 description: format!("Event: {}", event),

--- a/src-tauri/src/agents/droid.rs
+++ b/src-tauri/src/agents/droid.rs
@@ -96,7 +96,18 @@ impl AgentAdapter for DroidAdapter {
                 terminal: "".to_string(),
                 agent_type: "droid".to_string(),
             }),
-            "session_end" | "Stop" => Ok(AgentEvent::SessionEnd { session_id }),
+            "session_end" => Ok(AgentEvent::SessionEnd { session_id }),
+            "Stop" => Ok(AgentEvent::AssistantResponseComplete {
+                session_id,
+                text: raw
+                    .get("summary")
+                    .or_else(|| raw.get("last_assistant_message"))
+                    .or_else(|| raw.get("message"))
+                    .and_then(|v| v.as_str())
+                    .filter(|v| !v.trim().is_empty())
+                    .unwrap_or("Task completed")
+                    .to_string(),
+            }),
             _ => Ok(AgentEvent::Processing {
                 session_id,
                 description: format!("Event: {}", event),

--- a/src-tauri/src/agents/executable.rs
+++ b/src-tauri/src/agents/executable.rs
@@ -28,11 +28,78 @@ fn which(binary: &str) -> Option<PathBuf> {
         .map(PathBuf::from)
 }
 
+fn user_shell() -> String {
+    std::env::var("SHELL")
+        .ok()
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| "/bin/zsh".to_string())
+}
+
+fn is_fish(shell: &str) -> bool {
+    shell.ends_with("/fish")
+}
+
+fn shell_var_fallback_cmd(var: &str) -> String {
+    let shell = user_shell();
+    if is_fish(&shell) {
+        format!("printf '%s' \"${}\"", var)
+    } else {
+        format!("printf '%s' \"${{{}:-}}\"", var)
+    }
+}
+
+pub fn login_shell_var(var: &str) -> Option<String> {
+    let shell = user_shell();
+    let cmd = shell_var_fallback_cmd(var);
+    let output = std::process::Command::new(&shell)
+        .args(["-lc", &cmd])
+        .stdin(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let val = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if val.is_empty() {
+        None
+    } else {
+        Some(val)
+    }
+}
+
+fn login_shell_path() -> Option<Vec<PathBuf>> {
+    let shell = user_shell();
+    let cmd = if is_fish(&shell) {
+        "printf '%s' (string join ':' $PATH)"
+    } else {
+        "printf '%s' \"$PATH\""
+    };
+    let output = std::process::Command::new(shell)
+        .args(["-lc", cmd])
+        .stdin(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let path_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if path_str.is_empty() {
+        return None;
+    }
+    Some(std::env::split_paths(&path_str).collect())
+}
+
 fn candidate_dirs() -> Vec<PathBuf> {
     let mut dirs = BTreeSet::new();
 
     if let Some(path) = std::env::var_os("PATH") {
         dirs.extend(std::env::split_paths(&path));
+    }
+
+    if let Some(shell_paths) = login_shell_path() {
+        dirs.extend(shell_paths);
     }
 
     dirs.extend([
@@ -52,6 +119,8 @@ fn candidate_dirs() -> Vec<PathBuf> {
             home.join(".cargo").join("bin"),
         ]);
         dirs.extend(nvm_node_bins(&home));
+        dirs.extend(volta_bin(&home));
+        dirs.extend(mise_shims(&home));
     }
 
     dirs.into_iter().collect()
@@ -68,4 +137,14 @@ fn nvm_node_bins(home: &Path) -> Vec<PathBuf> {
         .map(|entry| entry.path().join("bin"))
         .filter(|path| path.is_dir())
         .collect()
+}
+
+fn volta_bin(home: &Path) -> Option<PathBuf> {
+    let path = home.join(".volta").join("bin");
+    path.is_dir().then_some(path)
+}
+
+fn mise_shims(home: &Path) -> Option<PathBuf> {
+    let path = home.join(".local").join("share").join("mise").join("shims");
+    path.is_dir().then_some(path)
 }

--- a/src-tauri/src/agents/gemini.rs
+++ b/src-tauri/src/agents/gemini.rs
@@ -92,7 +92,17 @@ impl AgentAdapter for GeminiAdapter {
                 terminal: string_field(raw, &["tty"]).unwrap_or("").to_string(),
                 agent_type: "gemini".to_string(),
             }),
-            "SessionEnd" | "session_end" | "Stop" => Ok(AgentEvent::SessionEnd { session_id }),
+            "SessionEnd" | "session_end" => Ok(AgentEvent::SessionEnd { session_id }),
+            "Stop" => {
+                let summary = string_field(raw, &["summary", "message", "last_assistant_message"])
+                    .filter(|v| !v.trim().is_empty())
+                    .unwrap_or("Task completed")
+                    .to_string();
+                Ok(AgentEvent::AssistantResponseComplete {
+                    session_id,
+                    text: summary,
+                })
+            }
             "BeforeTool" | "PreToolUse" | "pre_tool_use" => Ok(AgentEvent::ToolUse {
                 session_id,
                 tool_name,

--- a/src-tauri/src/agents/hermes.rs
+++ b/src-tauri/src/agents/hermes.rs
@@ -89,7 +89,18 @@ impl AgentAdapter for HermesAdapter {
                 terminal: "".to_string(),
                 agent_type: "hermes".to_string(),
             }),
-            "session_end" | "Stop" => Ok(AgentEvent::SessionEnd { session_id }),
+            "session_end" => Ok(AgentEvent::SessionEnd { session_id }),
+            "Stop" => Ok(AgentEvent::AssistantResponseComplete {
+                session_id,
+                text: raw
+                    .get("summary")
+                    .or_else(|| raw.get("last_assistant_message"))
+                    .or_else(|| raw.get("message"))
+                    .and_then(|v| v.as_str())
+                    .filter(|v| !v.trim().is_empty())
+                    .unwrap_or("Task completed")
+                    .to_string(),
+            }),
             _ => Ok(AgentEvent::Processing {
                 session_id,
                 description: format!("Event: {}", event),

--- a/src-tauri/src/agents/kiro.rs
+++ b/src-tauri/src/agents/kiro.rs
@@ -114,9 +114,18 @@ impl AgentAdapter for KiroAdapter {
                 tool_target: None,
                 status: "success".to_string(),
             }),
-            "session_end" | "SessionEnd" | "stop" | "Stop" => {
-                Ok(AgentEvent::SessionEnd { session_id })
-            }
+            "session_end" | "SessionEnd" => Ok(AgentEvent::SessionEnd { session_id }),
+            "stop" | "Stop" => Ok(AgentEvent::AssistantResponseComplete {
+                session_id,
+                text: raw
+                    .get("summary")
+                    .or_else(|| raw.get("last_assistant_message"))
+                    .or_else(|| raw.get("message"))
+                    .and_then(|v| v.as_str())
+                    .filter(|v| !v.trim().is_empty())
+                    .unwrap_or("Task completed")
+                    .to_string(),
+            }),
             _ => Ok(AgentEvent::Processing {
                 session_id,
                 description: format!("Event: {}", event),

--- a/src-tauri/src/agents/opencode.rs
+++ b/src-tauri/src/agents/opencode.rs
@@ -93,7 +93,20 @@ impl AgentAdapter for OpenCodeAdapter {
                     .to_string(),
                 agent_type: "opencode".to_string(),
             }),
-            "SessionEnd" | "Stop" => Ok(AgentEvent::SessionEnd { session_id }),
+            "SessionEnd" => Ok(AgentEvent::SessionEnd { session_id }),
+            "Stop" => {
+                let summary = raw
+                    .get("summary")
+                    .or_else(|| raw.get("message"))
+                    .and_then(|v| v.as_str())
+                    .filter(|v| !v.trim().is_empty())
+                    .unwrap_or("Task completed")
+                    .to_string();
+                Ok(AgentEvent::AssistantResponseComplete {
+                    session_id,
+                    text: summary,
+                })
+            }
             "PreToolUse" => Ok(AgentEvent::ToolUse {
                 session_id,
                 tool_name: raw

--- a/src-tauri/src/agents/pi.rs
+++ b/src-tauri/src/agents/pi.rs
@@ -95,7 +95,18 @@ impl AgentAdapter for PiAdapter {
                 terminal: "".to_string(),
                 agent_type: "pi".to_string(),
             }),
-            "session_end" | "Stop" => Ok(AgentEvent::SessionEnd { session_id }),
+            "session_end" => Ok(AgentEvent::SessionEnd { session_id }),
+            "Stop" => Ok(AgentEvent::AssistantResponseComplete {
+                session_id,
+                text: raw
+                    .get("summary")
+                    .or_else(|| raw.get("last_assistant_message"))
+                    .or_else(|| raw.get("message"))
+                    .and_then(|v| v.as_str())
+                    .filter(|v| !v.trim().is_empty())
+                    .unwrap_or("Task completed")
+                    .to_string(),
+            }),
             _ => Ok(AgentEvent::Processing {
                 session_id,
                 description: format!("Event: {}", event),

--- a/src-tauri/src/agents/profiles.rs
+++ b/src-tauri/src/agents/profiles.rs
@@ -587,7 +587,18 @@ pub fn droid_profile() -> AgentIntegrationProfile {
 }
 
 pub fn gemini_profile() -> AgentIntegrationProfile {
-    command_only_json_profile("gemini", ".gemini/settings.json", GEMINI_EVENTS)
+    AgentIntegrationProfile {
+        id: "gemini",
+        installation_kind: InstallationKind::JsonHooks {
+            entry: JsonHookEntry::TypedCommand,
+            nested: true,
+        },
+        configuration_path: ".gemini/settings.json",
+        activation_path: None,
+        source: "gemini",
+        extra_args: &[],
+        events: GEMINI_EVENTS,
+    }
 }
 
 pub fn kiro_profile() -> AgentIntegrationProfile {

--- a/src-tauri/src/agents/qoder_cli.rs
+++ b/src-tauri/src/agents/qoder_cli.rs
@@ -99,7 +99,18 @@ impl AgentAdapter for QoderCliAdapter {
                     .to_string(),
                 agent_type: "qoder-cli".to_string(),
             }),
-            "session_end" | "Stop" => Ok(AgentEvent::SessionEnd { session_id }),
+            "session_end" => Ok(AgentEvent::SessionEnd { session_id }),
+            "Stop" => Ok(AgentEvent::AssistantResponseComplete {
+                session_id,
+                text: raw
+                    .get("summary")
+                    .or_else(|| raw.get("last_assistant_message"))
+                    .or_else(|| raw.get("message"))
+                    .and_then(|v| v.as_str())
+                    .filter(|v| !v.trim().is_empty())
+                    .unwrap_or("Task completed")
+                    .to_string(),
+            }),
             _ => Ok(AgentEvent::Processing {
                 session_id,
                 description: format!("Event: {}", event),

--- a/src-tauri/src/agents/stepfun.rs
+++ b/src-tauri/src/agents/stepfun.rs
@@ -95,7 +95,18 @@ impl AgentAdapter for StepFunAdapter {
                 terminal: "".to_string(),
                 agent_type: "stepfun".to_string(),
             }),
-            "session_end" | "Stop" => Ok(AgentEvent::SessionEnd { session_id }),
+            "session_end" => Ok(AgentEvent::SessionEnd { session_id }),
+            "Stop" => Ok(AgentEvent::AssistantResponseComplete {
+                session_id,
+                text: raw
+                    .get("summary")
+                    .or_else(|| raw.get("last_assistant_message"))
+                    .or_else(|| raw.get("message"))
+                    .and_then(|v| v.as_str())
+                    .filter(|v| !v.trim().is_empty())
+                    .unwrap_or("Task completed")
+                    .to_string(),
+            }),
             _ => Ok(AgentEvent::Processing {
                 session_id,
                 description: format!("Event: {}", event),

--- a/src-tauri/src/agents/trae_cli.rs
+++ b/src-tauri/src/agents/trae_cli.rs
@@ -111,7 +111,18 @@ impl AgentAdapter for TraeCliAdapter {
                     .to_string(),
                 agent_type: "traecli".to_string(),
             }),
-            "session_end" | "SessionEnd" | "Stop" => Ok(AgentEvent::SessionEnd { session_id }),
+            "session_end" | "SessionEnd" => Ok(AgentEvent::SessionEnd { session_id }),
+            "Stop" => Ok(AgentEvent::AssistantResponseComplete {
+                session_id,
+                text: raw
+                    .get("summary")
+                    .or_else(|| raw.get("last_assistant_message"))
+                    .or_else(|| raw.get("message"))
+                    .and_then(|v| v.as_str())
+                    .filter(|v| !v.trim().is_empty())
+                    .unwrap_or("Task completed")
+                    .to_string(),
+            }),
             "PreToolUse" | "pre_tool_use" => Ok(AgentEvent::ToolUse {
                 session_id,
                 tool_name: raw

--- a/src-tauri/src/agents/workbuddy.rs
+++ b/src-tauri/src/agents/workbuddy.rs
@@ -95,7 +95,18 @@ impl AgentAdapter for WorkBuddyAdapter {
                 terminal: "".to_string(),
                 agent_type: "workbuddy".to_string(),
             }),
-            "session_end" | "Stop" => Ok(AgentEvent::SessionEnd { session_id }),
+            "session_end" => Ok(AgentEvent::SessionEnd { session_id }),
+            "Stop" => Ok(AgentEvent::AssistantResponseComplete {
+                session_id,
+                text: raw
+                    .get("summary")
+                    .or_else(|| raw.get("last_assistant_message"))
+                    .or_else(|| raw.get("message"))
+                    .and_then(|v| v.as_str())
+                    .filter(|v| !v.trim().is_empty())
+                    .unwrap_or("Task completed")
+                    .to_string(),
+            }),
             _ => Ok(AgentEvent::Processing {
                 session_id,
                 description: format!("Event: {}", event),

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4466,6 +4466,72 @@ pub async fn run_hook_doctor(state: State<'_, AppState>) -> Result<HookDoctorRep
         });
     }
 
+    if let Some(warning) = check_bare_mode() {
+        checks.push(HookDoctorCheck {
+            id: "claude-bare-mode".to_string(),
+            label: "Claude Code bare mode".to_string(),
+            status: "error".to_string(),
+            detail: warning,
+        });
+    } else {
+        checks.push(HookDoctorCheck {
+            id: "claude-bare-mode".to_string(),
+            label: "Claude Code bare mode".to_string(),
+            status: "ok".to_string(),
+            detail: "CLAUDE_CODE_SIMPLE is not set".to_string(),
+        });
+    }
+
+    {
+        let home = dirs::home_dir();
+        let trust_path = home.as_ref().map(|h| h.join(".gemini").join("trustedFolders.json"));
+        let cwd = std::env::current_dir().ok();
+        let mut trust_ok = true;
+        let mut trust_detail = "Gemini folder trust: no working directory".to_string();
+
+        if let (Some(trust_path), Some(cwd)) = (&trust_path, &cwd) {
+            if let Ok(content) = std::fs::read_to_string(trust_path) {
+                if let Ok(trust) = serde_json::from_str::<serde_json::Value>(&content) {
+                    if let Some(obj) = trust.as_object() {
+                        for (_path, level) in obj {
+                            if level.as_str() == Some("TRUST_PARENT") {
+                                let parent = std::path::PathBuf::from(_path);
+                                if cwd.starts_with(&parent) {
+                                    trust_detail = format!("{} is trusted via {}", cwd.display(), _path);
+                                    trust_ok = true;
+                                    break;
+                                }
+                                trust_ok = false;
+                                trust_detail = format!(
+                                    "{} is NOT in any trusted folder. Add it via: gemini trust",
+                                    cwd.display()
+                                );
+                            } else if level.as_str() == Some("TRUST_FOLDER") {
+                                if _path == &cwd.display().to_string() {
+                                    trust_detail = format!("{} is trusted", cwd.display());
+                                    trust_ok = true;
+                                    break;
+                                }
+                                trust_ok = false;
+                                trust_detail = format!(
+                                    "{} is NOT in any trusted folder. Add it via: gemini trust",
+                                    cwd.display()
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        checks.push(HookDoctorCheck {
+            id: "gemini-folder-trust".to_string(),
+            label: "Gemini folder trust".to_string(),
+            status: if trust_ok { "ok" } else { "warn" }.to_string(),
+            detail: trust_detail,
+        });
+    }
+
     Ok(HookDoctorReport {
         generated_at: chrono::Utc::now().timestamp(),
         checks,
@@ -4692,6 +4758,67 @@ pub async fn set_agent_default_pet(
 
 // ── Hook Management Commands ──────────────────────────────────────
 
+pub fn check_bare_mode() -> Option<String> {
+    if std::env::var("CLAUDE_CODE_SIMPLE").ok().as_deref() == Some("1") {
+        return Some("CLAUDE_CODE_SIMPLE=1 is set in the process environment.".to_string());
+    }
+    if let Some(val) = crate::agents::executable::login_shell_var("CLAUDE_CODE_SIMPLE") {
+        if val == "1" {
+            let shell = std::env::var("SHELL")
+                .ok()
+                .unwrap_or_else(|| "/bin/zsh".to_string());
+            return Some(format!(
+                "CLAUDE_CODE_SIMPLE=1 is set in {} config (bare mode skips all hooks).",
+                shell.rsplit('/').next().unwrap_or("shell")
+            ));
+        }
+    }
+    None
+}
+
+pub fn ensure_gemini_folder_trust() {
+    let home = match dirs::home_dir() {
+        Some(h) => h,
+        None => return,
+    };
+    let trust_path = home.join(".gemini").join("trustedFolders.json");
+    let cwd = match std::env::current_dir() {
+        Ok(d) => d,
+        Err(_) => return,
+    };
+    let cwd_str = cwd.display().to_string();
+
+    let mut trust: serde_json::Value = match std::fs::read_to_string(&trust_path) {
+        Ok(content) => serde_json::from_str(&content).unwrap_or(serde_json::json!({})),
+        Err(_) => serde_json::json!({}),
+    };
+
+    if let Some(obj) = trust.as_object() {
+        for (_path, level) in obj {
+            if level.as_str() == Some("TRUST_PARENT") {
+                let parent = std::path::PathBuf::from(_path);
+                if cwd.starts_with(&parent) {
+                    return;
+                }
+            }
+            if level.as_str() == Some("TRUST_FOLDER") && _path == &cwd_str {
+                return;
+            }
+        }
+    }
+
+    if let Some(obj) = trust.as_object_mut() {
+        obj.insert(cwd_str.clone(), serde_json::json!("TRUST_PARENT"));
+    }
+    if let Some(parent) = trust_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(formatted) = serde_json::to_string_pretty(&trust) {
+        let _ = std::fs::write(&trust_path, formatted);
+        log::info!("Added {} to Gemini trusted folders", cwd_str);
+    }
+}
+
 #[tauri::command]
 pub async fn install_hooks(state: State<'_, AppState>, agent: String) -> Result<(), String> {
     log::info!("Installing hooks for agent: {}", agent);
@@ -4705,11 +4832,23 @@ pub async fn install_hooks(state: State<'_, AppState>, agent: String) -> Result<
         crate::agents::AdapterStatus::Unavailable
     ) {
         return Err(format!(
-            "{} CLI not found on PATH. Install it first, then try again.",
+            "{} CLI not found. Searched process PATH, login shell PATH, \
+             and common directories (homebrew, nvm, volta, mise, cargo). \
+             Confirm it is installed and try restarting AgentBro.",
             adapter.display_name()
         ));
     }
     adapter.install_hooks().map_err(|e| e.to_string())?;
+
+    if agent == "claude-code" {
+        if let Some(warning) = check_bare_mode() {
+            log::warn!("Claude Code bare mode detected: {}", warning);
+        }
+    }
+    if agent == "gemini" {
+        ensure_gemini_folder_trust();
+    }
+
     if let Err(e) = state.config_store.mark_agent_enabled(&agent) {
         log::warn!(
             "Failed to persist enabled-agent intent for {}: {}",

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4484,7 +4484,9 @@ pub async fn run_hook_doctor(state: State<'_, AppState>) -> Result<HookDoctorRep
 
     {
         let home = dirs::home_dir();
-        let trust_path = home.as_ref().map(|h| h.join(".gemini").join("trustedFolders.json"));
+        let trust_path = home
+            .as_ref()
+            .map(|h| h.join(".gemini").join("trustedFolders.json"));
         let cwd = std::env::current_dir().ok();
         let mut trust_ok = true;
         let mut trust_detail = "Gemini folder trust: no working directory".to_string();
@@ -4497,7 +4499,8 @@ pub async fn run_hook_doctor(state: State<'_, AppState>) -> Result<HookDoctorRep
                             if level.as_str() == Some("TRUST_PARENT") {
                                 let parent = std::path::PathBuf::from(_path);
                                 if cwd.starts_with(&parent) {
-                                    trust_detail = format!("{} is trusted via {}", cwd.display(), _path);
+                                    trust_detail =
+                                        format!("{} is trusted via {}", cwd.display(), _path);
                                     trust_ok = true;
                                     break;
                                 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -386,7 +386,9 @@ fn expand_tilde_target(target: &str) -> String {
 fn ensure_installable(adapter: &dyn AgentAdapter) -> Result<(), String> {
     match adapter.detect_status_now() {
         AdapterStatus::Unavailable => Err(format!(
-            "{} CLI not found on PATH. Install it first, then try again.",
+            "{} CLI not found. Searched process PATH, login shell PATH, \
+             and common directories (homebrew, nvm, volta, mise, cargo). \
+             Confirm it is installed and try restarting AgentBro.",
             adapter.display_name()
         )),
         _ => Ok(()),
@@ -435,6 +437,16 @@ async fn install_agent_hook(
         .ok_or_else(|| format!("Unknown tool: {}", tool_name))?;
     ensure_installable(adapter.as_ref())?;
     adapter.install_hooks().map_err(|e| e.to_string())?;
+
+    if adapter.name() == "claude-code" {
+        if let Some(warning) = commands::check_bare_mode() {
+            log::warn!("Claude Code bare mode detected: {}", warning);
+        }
+    }
+    if adapter.name() == "gemini" {
+        commands::ensure_gemini_folder_trust();
+    }
+
     if let Err(e) = state.config_store.mark_agent_enabled(adapter.name()) {
         log::warn!(
             "Failed to persist enabled-agent intent for {}: {}",
@@ -1944,8 +1956,52 @@ fn normalize_settings_window_frame(window: &tauri::WebviewWindow) {
             SETTINGS_DEFAULT_WIDTH,
             SETTINGS_DEFAULT_HEIGHT,
         )));
+    }
+
+    // `window.center()` can silently fail on invisible windows or when the
+    // display layout has changed. Compute the position explicitly from the
+    // current monitor's work area.
+    center_on_current_monitor(window, SETTINGS_DEFAULT_WIDTH, SETTINGS_DEFAULT_HEIGHT);
+}
+
+fn center_on_current_monitor(window: &tauri::WebviewWindow, width: f64, height: f64) {
+    let monitor = find_cursor_monitor(window)
+        .or_else(|| window.current_monitor().ok().flatten())
+        .or_else(|| window.primary_monitor().ok().flatten());
+
+    if let Some(monitor) = monitor {
+        let scale = monitor.scale_factor();
+        let work_area = monitor.work_area();
+        let screen_w = work_area.size.width as f64 / scale;
+        let screen_h = work_area.size.height as f64 / scale;
+        let screen_x = work_area.position.x as f64 / scale;
+        let screen_y = work_area.position.y as f64 / scale;
+
+        let x = screen_x + (screen_w - width) / 2.0;
+        let y = screen_y + (screen_h - height) / 2.0;
+
+        let _ = window.set_position(tauri::Position::Logical(tauri::LogicalPosition::new(
+            x.max(screen_x),
+            y.max(screen_y),
+        )));
+    } else {
         let _ = window.center();
     }
+}
+
+fn find_cursor_monitor(window: &tauri::WebviewWindow) -> Option<tauri::Monitor> {
+    let (cx, cy) = get_cursor_position_sync().ok()?;
+    let monitors = window.available_monitors().ok()?;
+    monitors.into_iter().find(|m| {
+        let s = m.scale_factor();
+        let pos = m.position();
+        let size = m.size();
+        let x = pos.x as f64 / s;
+        let y = pos.y as f64 / s;
+        let w = size.width as f64 / s;
+        let h = size.height as f64 / s;
+        cx >= x && cx < x + w && cy >= y && cy < y + h
+    })
 }
 
 fn show_settings_window(app: &tauri::AppHandle) -> Result<(), String> {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2483,7 +2483,7 @@ async fn get_central_skill_bundles() -> Result<Vec<skills::CentralSkillBundle>, 
     for bundle in &mut bundles {
         bundle.skill_ids.sort();
     }
-    bundles.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    bundles.sort_by_key(|a| a.name.to_lowercase());
     Ok(bundles)
 }
 

--- a/src-tauri/src/market/mod.rs
+++ b/src-tauri/src/market/mod.rs
@@ -64,29 +64,12 @@ fn proxy_from_env() -> Option<String> {
 }
 
 async fn proxy_from_login_shell() -> Option<String> {
-    let shell = std::env::var("SHELL")
-        .ok()
-        .filter(|value| !value.trim().is_empty())
-        .unwrap_or_else(|| "/bin/zsh".to_string());
-    let output = Command::new(shell)
-        .args([
-            "-lc",
-            "printf '%s' \"${HTTPS_PROXY:-${https_proxy:-${HTTP_PROXY:-${http_proxy:-}}}}\"",
-        ])
-        .stdin(Stdio::null())
-        .stderr(Stdio::null())
-        .output()
-        .await
-        .ok()?;
-    if !output.status.success() {
-        return None;
+    for var in &["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"] {
+        if let Some(val) = crate::agents::executable::login_shell_var(var) {
+            return Some(val);
+        }
     }
-    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    if value.is_empty() {
-        None
-    } else {
-        Some(value)
-    }
+    None
 }
 
 async fn market_http_client() -> reqwest::Client {

--- a/src-tauri/src/skills/registry.rs
+++ b/src-tauri/src/skills/registry.rs
@@ -160,7 +160,7 @@ pub fn delete_pack(id: &str) -> Result<(), String> {
 
 pub fn list_collections() -> Vec<SkillCollection> {
     let mut collections = load().collections;
-    collections.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    collections.sort_by_key(|a| a.name.to_lowercase());
     collections
 }
 

--- a/src-tauri/src/skills/scanner.rs
+++ b/src-tauri/src/skills/scanner.rs
@@ -90,7 +90,7 @@ pub fn get_obsidian_vaults() -> Vec<ObsidianVault> {
             break;
         }
     }
-    vaults.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    vaults.sort_by_key(|a| a.name.to_lowercase());
     vaults
 }
 

--- a/src-tauri/src/switch/deeplink.rs
+++ b/src-tauri/src/switch/deeplink.rs
@@ -13,10 +13,8 @@ pub fn parse_deep_link(url: &str) -> Option<DeepLinkPayload> {
     let url = url.trim();
     let stripped = if let Some(rest) = url.strip_prefix("agentbro://") {
         rest
-    } else if let Some(rest) = url.strip_prefix("ccswitch://") {
-        rest
     } else {
-        return None;
+        url.strip_prefix("ccswitch://")?
     };
 
     let path_and_query: Vec<&str> = stripped.splitn(2, '?').collect();


### PR DESCRIPTION
## Summary

- fix: resolve CLI PATH detection for GUI apps — expand `PATH` from shell profile so launchers like Raycast/Alfred can find CLI tools
- fix: map `Stop` event to `AssistantResponseComplete` in all adapters
- fix: use nested hook format for Gemini adapter
- fix: center settings window on current monitor
- feat: add hook diagnostics and auto-repair for bare mode and folder trust

## Changes

20 files changed across adapters, commands, and lib — adds `executable` agent module, enriches `commands/mod.rs` with diagnostics/repair IPC, and tightens hook event mapping in every adapter.