### PR TITLE
fix: 修复外接显示器灵动岛定位失败及主屏点击遮盖问题

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -145,18 +145,14 @@ async fn set_notch_focusable(app: tauri::AppHandle, focusable: bool) -> Result<(
 #[tauri::command]
 async fn set_notch_ignore_cursor_events(
     app: tauri::AppHandle,
-    _ignore: bool,
+    ignore: bool,
     window_label: Option<String>,
 ) -> Result<(), String> {
-    // Always force the window to receive cursor events. Toggling ignore=true
-    // on a transparent Tauri window is unreliable on macOS external displays
-    // (clicks pass through the visible notch). CSS `pointer-events` on the
-    // .notch-container/.notch-hitbox pair handles visual click-through.
     let label = window_label.unwrap_or_else(|| "notch".to_string());
     let handle = app.clone();
     app.run_on_main_thread(move || {
         if let Some(window) = handle.get_webview_window(&label) {
-            let _ = window.set_ignore_cursor_events(false);
+            let _ = window.set_ignore_cursor_events(ignore);
         }
     })
     .map_err(|e| e.to_string())
@@ -1526,11 +1522,6 @@ async fn is_cursor_over_notch(
         let size = window.outer_size().map_err(|e| e.to_string())?;
         let scale = window.scale_factor().unwrap_or(1.0).max(1.0);
 
-        // Normalize both cursor and window to absolute logical coordinates.
-        // On macOS with external monitors, window.outer_position() and
-        // app.cursor_position() can report values in different coordinate
-        // spaces depending on which monitor the window is on. Convert both
-        // to monitor-relative logical coordinates for a consistent hit test.
         let monitor = window.current_monitor().ok().flatten();
         let monitor_origin_logical = monitor
             .map(|m| {

--- a/src-tauri/src/platform/display.rs
+++ b/src-tauri/src/platform/display.rs
@@ -250,12 +250,13 @@ pub fn find_cursor_monitor(app: &tauri::AppHandle) -> Option<tauri::Monitor> {
     if let Ok(cursor) = app.cursor_position() {
         if let Ok(monitors) = app.available_monitors() {
             if let Some(monitor) = monitors.iter().find(|m| {
+                let scale = m.scale_factor().max(1.0);
                 let pos = m.position();
                 let size = m.size();
-                let x = pos.x as f64;
-                let y = pos.y as f64;
-                let width = size.width as f64;
-                let height = size.height as f64;
+                let x = pos.x as f64 / scale;
+                let y = pos.y as f64 / scale;
+                let width = size.width as f64 / scale;
+                let height = size.height as f64 / scale;
                 cursor.x >= x && cursor.x <= x + width && cursor.y >= y && cursor.y <= y + height
             }) {
                 return Some(monitor.clone());


### PR DESCRIPTION
## 修复问题

### 1. 外接显示器灵动岛定位失败（核心 bug）

**根因**：`find_cursor_monitor` 的第一个光标-显示器匹配检查存在坐标空间错误——将逻辑坐标（`app.cursor_position()` 返回的 NSEvent::mouseLocation）与物理坐标（`m.position()` / `m.size()`）直接比较。Retina 2x 显示器下永远匹配失败，导致灵动岛窗口始终定位在主屏。

**修复**：对 `m.position()` 和 `m.size()` 除以 `scale_factor`，统一为逻辑坐标空间。

**表现**：外接屏上灵动岛 hover/click 完全无响应。

**文件**：`src-tauri/src/platform/display.rs`

### 2. 主屏点击遮盖（大区域拦截点击）

**根因**：`set_notch_ignore_cursor_events` 始终传入 `false`（忽略参数），导致 collapsed 态下 host 窗口（754px）拦截所有点击，包括 notch 下方区域。

**修复**：恢复使用 `ignore` 参数进行动态 toggle——collapsed 态设为 `true`（点击穿透），hover/expanded 态设为 `false`（notch 捕获交互）。

**表现**：notch 下方区域无法点击，被 host 窗口遮盖。

**文件**：`src-tauri/src/lib.rs`
