### PR TITLE
ci: add Windows release installer workflow

### DIFF
--- a/.github/release-notes.md
+++ b/.github/release-notes.md
@@ -24,13 +24,14 @@ This hotfix restores reliable notch placement and click-through behavior on exte
 
 - Recommended download: `AgentBro_latest_universal.dmg`
 - Versioned archive: `AgentBro_{{VERSION}}_universal.dmg`
+- Stable Windows installers: `AgentBro_latest_x64-setup.exe` and `AgentBro_latest_x64.msi`; prereleases use versioned installer names.
 - Auto update files: `AgentBro.app.tar.gz` and `latest.json`
 - Mainland China mirror: `https://agentbro.oss-cn-hangzhou.aliyuncs.com/AgentBro_latest_universal.dmg`
 
 ### Notes
 
-- This version primarily supports macOS.
-- Windows support will come in a later phase.
+- macOS remains the primary, signed release channel.
+- Windows installers are early MVP artifacts and may show SmartScreen warnings until Windows code signing is configured.
 
 ## 中文
 
@@ -56,10 +57,11 @@ This hotfix restores reliable notch placement and click-through behavior on exte
 
 - 推荐下载: `AgentBro_latest_universal.dmg`
 - 版本归档: `AgentBro_{{VERSION}}_universal.dmg`
+- 稳定版 Windows 安装包: `AgentBro_latest_x64-setup.exe` 与 `AgentBro_latest_x64.msi`; 预览版使用带版本号的安装包文件名。
 - 自动更新文件: `AgentBro.app.tar.gz` 与 `latest.json`
 - 国内直链: `https://agentbro.oss-cn-hangzhou.aliyuncs.com/AgentBro_latest_universal.dmg`
 
 ### 说明
 
-- 当前版本主要支持 macOS。
-- Windows 支持会放在后续阶段推进。
+- macOS 仍是主要的签名发布渠道。
+- Windows 安装包属于早期 MVP 产物，在配置 Windows 代码签名前可能出现 SmartScreen 提示。

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, master, develop]
   pull_request:
-    branches: [main, master]
+    branches: [dev, main, master]
   workflow_dispatch:
 
 permissions:
@@ -67,4 +67,51 @@ jobs:
         with:
           name: agentbro-${{ matrix.arch }}
           path: src-tauri/target/${{ matrix.rust-target }}/release/agentbro
+          if-no-files-found: error
+
+  build-windows:
+    name: Build Windows installers
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Release readiness check
+        run: pnpm release:check
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Install Tauri CLI
+        run: cargo install tauri-cli --locked
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Tauri installers
+        run: pnpm tauri:build:windows
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: agentbro-windows-installers
+          path: |
+            src-tauri/target/release/bundle/nsis/*.exe
+            src-tauri/target/release/bundle/msi/*.msi
           if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,6 +191,94 @@ jobs:
           oss_cp "dist/AgentBro.app.tar.gz.sig"          "${base}/AgentBro.app.tar.gz.sig"
           oss_cp "dist/latest.oss.json"                  "${base}/latest.json"
 
+  build-windows:
+    name: Build Windows Installers
+    runs-on: windows-latest
+    needs: build-universal
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Release readiness check
+        run: pnpm release:check
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+
+      - name: Install Tauri CLI
+        run: cargo install tauri-cli --locked
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Windows installers
+        shell: pwsh
+        run: |
+          pnpm tauri:build:windows
+
+          $windowsDist = "dist/windows"
+          New-Item -ItemType Directory -Force -Path $windowsDist | Out-Null
+
+          $nsisDir = "src-tauri/target/release/bundle/nsis"
+          $msiDir = "src-tauri/target/release/bundle/msi"
+          $nsisFiles = if (Test-Path $nsisDir) { @(Get-ChildItem -Path $nsisDir -Filter "*.exe" -File) } else { @() }
+          $msiFiles = if (Test-Path $msiDir) { @(Get-ChildItem -Path $msiDir -Filter "*.msi" -File) } else { @() }
+          $installerFiles = @($nsisFiles + $msiFiles)
+
+          if ($installerFiles.Count -eq 0) {
+            throw "No Windows installer artifacts were produced."
+          }
+
+          foreach ($file in $installerFiles) {
+            Copy-Item -LiteralPath $file.FullName -Destination $windowsDist
+          }
+
+          if ("${{ github.ref_name }}" -notlike "*-*") {
+            $latestExe = $nsisFiles | Sort-Object Name | Select-Object -First 1
+            if ($latestExe) {
+              Copy-Item -LiteralPath $latestExe.FullName -Destination "$windowsDist/AgentBro_latest_x64-setup.exe"
+            }
+
+            $latestMsi = $msiFiles | Sort-Object Name | Select-Object -First 1
+            if ($latestMsi) {
+              Copy-Item -LiteralPath $latestMsi.FullName -Destination "$windowsDist/AgentBro_latest_x64.msi"
+            }
+          }
+
+          Get-ChildItem -Path $windowsDist -File | Sort-Object Name | ForEach-Object {
+            $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $_.FullName).Hash.ToLowerInvariant()
+            "$hash  $($_.Name)"
+          } | Set-Content -Path "$windowsDist/checksums-windows.txt" -Encoding ascii
+
+          Get-ChildItem -Path $windowsDist -File | Sort-Object Name
+
+      - name: Upload Windows installers to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/windows/*.exe
+            dist/windows/*.msi
+            dist/windows/checksums-windows.txt
+          overwrite_files: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
+
   update-homebrew:
     name: Update Homebrew Cask
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -147,9 +147,9 @@ AgentBro 会坚持本地优先：第一个公开版本先把灵动岛、Hook 集
 
 ## 平台支持
 
-AgentBro 当前优先开发、测试和发布 **macOS** 版本。
+AgentBro 当前优先开发和测试 **macOS** 版本，并提供早期 **Windows MVP** 安装包。
 
-Windows 支持在计划中。Tauri + React + Rust 的基础架构具备跨平台能力，但一个体验良好的 Windows 版本还需要单独适配悬浮窗口、托盘、快捷键、终端/编辑器焦点检测、Hook 路径、安装包、签名和发布流程。
+Windows 版本已经具备基础悬浮窗口、Hook 传输、路径探测和安装包构建能力，但仍属于早期支持；签名、SmartScreen 体验、自动更新和部分 Agent 深度集成还会继续完善。
 
 Linux 后续也可以支持，但不属于第一个公开版本的目标。
 
@@ -172,7 +172,8 @@ brew install --cask agentbro
 
 ### 下载发行版
 
-- 🇨🇳 国内直链（推荐，速度快）：[下载最新 DMG](https://agentbro.oss-cn-hangzhou.aliyuncs.com/AgentBro_latest_universal.dmg)
+- 🇨🇳 macOS 国内直链（推荐，速度快）：[下载最新 DMG](https://agentbro.oss-cn-hangzhou.aliyuncs.com/AgentBro_latest_universal.dmg)
+- Windows 安装包：在 [GitHub Releases](https://github.com/shirenchuang/agentbro/releases) 下载 `AgentBro_latest_x64-setup.exe` 或 `AgentBro_latest_x64.msi`
 - 🌍 海外 / 全部版本：[GitHub Releases](https://github.com/shirenchuang/agentbro/releases)
 
 ## 本地开发
@@ -218,6 +219,7 @@ pnpm lint          # ESLint
 pnpm build         # 类型检查并构建前端
 cargo check        # 检查 Rust 后端
 pnpm tauri:build   # 构建 Tauri 应用
+pnpm tauri:build:windows # 构建 Windows NSIS/MSI 安装包
 ./build.sh         # 构建通用 macOS DMG
 ```
 

--- a/docs/plans/2026-06-09-windows-release-artifacts-design.md
+++ b/docs/plans/2026-06-09-windows-release-artifacts-design.md
@@ -1,0 +1,31 @@
+# Windows Release Artifacts Design
+
+## Goal
+
+Publish Windows MVP installers from the existing tag-driven release flow without destabilizing the signed macOS release path.
+
+## Chosen Approach
+
+Keep `build-universal` as the job that creates the GitHub Release and macOS updater artifacts. Add a separate `build-windows` job that depends on `build-universal`, runs on `windows-latest`, builds NSIS/MSI installers with `pnpm tauri:build:windows`, and attaches the resulting files to the same tag release.
+
+This avoids concurrent release creation races, keeps Homebrew and OSS behavior scoped to macOS, and makes Windows packaging failure visible in the release workflow conclusion.
+
+## Artifacts
+
+Stable tags upload:
+
+- The Tauri-emitted NSIS `.exe`
+- The Tauri-emitted MSI `.msi`
+- `AgentBro_latest_x64-setup.exe`
+- `AgentBro_latest_x64.msi`
+- `checksums-windows.txt`
+
+Prerelease tags upload only the versioned Tauri-emitted installer names and `checksums-windows.txt`.
+
+## Current Limits
+
+Windows installers are unsigned MVP artifacts. They may trigger SmartScreen warnings and are not wired into the Tauri updater manifest yet. Windows OSS mirrors can be added later if the website needs mainland China Windows download links.
+
+## Validation
+
+The non-release `Build` workflow also builds Windows installers and uploads them as Actions artifacts. Local validation covers YAML shape and release readiness; full Windows packaging validation runs on GitHub Actions.

--- a/docs/release.md
+++ b/docs/release.md
@@ -67,9 +67,11 @@ Preview releases:
 
 - Are marked as GitHub prereleases.
 - Build unsigned and unnotarized macOS DMGs.
+- Build unsigned Windows NSIS/MSI installers after the macOS release job succeeds.
 - Still include Tauri updater signatures.
 - Do not update the Homebrew tap.
-- May require users to right-click the app and choose Open on first launch.
+- May require users to right-click the macOS app and choose Open on first launch.
+- May show Windows SmartScreen warnings until Windows code signing is configured.
 
 ## Stable Release
 
@@ -89,6 +91,16 @@ The `Release` workflow builds a universal macOS release and uploads:
 - `AgentBro.app.tar.gz.sig`
 - `latest.json`
 - `checksums.txt`
+
+After the macOS release is created, the `Build Windows Installers` job builds and appends Windows artifacts to the same GitHub Release:
+
+- `AgentBro_*_x64-setup.exe` or the NSIS installer name emitted by Tauri
+- `AgentBro_*_x64*.msi` or the MSI installer name emitted by Tauri
+- `AgentBro_latest_x64-setup.exe` for stable tags
+- `AgentBro_latest_x64.msi` for stable tags
+- `checksums-windows.txt`
+
+Windows packages are unsigned MVP artifacts for now. Do not advertise them as SmartScreen-clean or auto-updating until Windows code signing and Windows updater manifests are added.
 
 When `HOMEBREW_TAP_TOKEN` is configured, the workflow also updates the Homebrew cask in the tap repository.
 
@@ -132,6 +144,7 @@ agentbro/                                               # OSS bucket "agentbro",
 How it works:
 
 - The `Mirror release to Aliyun OSS` step in `build-universal` runs after the GitHub release, only for stable tags and only when `OSS_ACCESS_KEY_ID`/`OSS_ACCESS_KEY_SECRET` are set.
+- Windows installer artifacts are currently attached to GitHub Releases only. Mirror them separately if the website needs mainland China Windows download links.
 - `latest.json` is GitHub-flavored by `build.sh`; the step derives an OSS variant with `sed`, rewriting the archive URL prefix from GitHub to OSS. The updater signature is over the archive bytes only, so URL rewriting keeps it valid — `build.sh` and `scripts/create-updater-manifest.mjs` are untouched.
 - `src-tauri/tauri.conf.json` lists two updater endpoints, OSS first then GitHub, so China hits OSS and falls back to GitHub.
 - The Homebrew cask `url` points at the OSS versioned path when OSS secrets are present, otherwise at GitHub.
@@ -164,10 +177,12 @@ curl -I https://agentbro.oss-cn-hangzhou.aliyuncs.com/AgentBro_latest_universal.
 
 Use `https://www.agentbro.net` as the public homepage and download entry.
 
-For the first release, the app updater can keep reading `latest.json` from GitHub Releases. The website only needs to point users to the latest DMG, for example:
+For the first release, the app updater can keep reading `latest.json` from GitHub Releases. The website only needs to point users to the latest installers, for example:
 
 - Stable download: `https://github.com/shirenchuang/agentbro/releases/latest`
 - Latest DMG download: `https://github.com/shirenchuang/agentbro/releases/latest/download/AgentBro_latest_universal.dmg`
+- Latest Windows NSIS download: `https://github.com/shirenchuang/agentbro/releases/latest/download/AgentBro_latest_x64-setup.exe`
+- Latest Windows MSI download: `https://github.com/shirenchuang/agentbro/releases/latest/download/AgentBro_latest_x64.msi`
 - Versioned DMG download after a tagged release: `https://github.com/shirenchuang/agentbro/releases/download/v<VERSION>/AgentBro_<VERSION>_universal.dmg`
 
 Only move the Tauri updater endpoint in `src-tauri/tauri.conf.json` to `www.agentbro.net` after the website or CDN reliably serves:
@@ -189,3 +204,6 @@ Before announcing a release:
 - Confirm Homebrew installs the same version.
 - Confirm anonymous usage stats are enabled by default and can be disabled in Settings.
 - Confirm an older app version updates through the Tauri updater.
+- Install both Windows artifacts on a clean Windows 11 machine.
+- Confirm Windows SmartScreen warning text is expected for unsigned builds.
+- Confirm the floating window, tray, hook transport, Codex/Codex Desktop detection, and launch-at-login behavior work on Windows.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:bridge:release": "node scripts/build-bridge.mjs --release",
     "tauri:dev": "pnpm build:bridge && cargo tauri dev",
     "tauri:build": "pnpm build:bridge:release && cargo tauri build --bundles app,dmg --no-sign --ci --config '{\"bundle\":{\"createUpdaterArtifacts\":false}}'",
-    "tauri:build:windows": "pnpm build:bridge:release && cargo tauri build --bundles nsis,msi --ci --config \"{\\\"bundle\\\":{\\\"createUpdaterArtifacts\\\":false}}\"",
+    "tauri:build:windows": "node scripts/build-windows.mjs",
     "release:check": "node scripts/check-release-readiness.mjs",
     "build": "tsc -b && vite build",
     "lint": "eslint .",

--- a/scripts/build-windows.mjs
+++ b/scripts/build-windows.mjs
@@ -1,0 +1,20 @@
+import { spawnSync } from 'node:child_process'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const rootDir = resolve(scriptDir, '..')
+const config = JSON.stringify({ bundle: { createUpdaterArtifacts: false } })
+
+const result = spawnSync(
+  'cargo',
+  ['tauri', 'build', '--bundles', 'nsis,msi', '--ci', '--config', config],
+  {
+    cwd: rootDir,
+    stdio: 'inherit',
+  },
+)
+
+if (result.status !== 0) {
+  process.exit(result.status ?? 1)
+}


### PR DESCRIPTION
## Summary

- add a Windows release job that builds NSIS/MSI installers on windows-latest and appends them to tag releases
- add a Windows installer build job to the non-release Build workflow for PR/manual validation
- move the Windows build command into a Node wrapper to avoid Windows shell JSON quoting issues
- update release docs, README, and release notes to describe unsigned Windows MVP artifacts

## Validation

- pnpm release:check
- pnpm lint
- pnpm test:run
- pnpm build
- node --check scripts/build-windows.mjs
- ruby YAML parse for build/release workflows
- git diff --check

## Notes

Windows installers are intentionally unsigned MVP artifacts for this step. They may show SmartScreen warnings until Windows code signing and updater manifests are added.