### PR TITLE
fix: 修复外接屏宠物拖动与点击

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1482,6 +1482,24 @@ async fn is_cursor_in_window_zones(
         let scale = window.scale_factor().unwrap_or(1.0).max(1.0);
 
         let monitor = window.current_monitor().ok().flatten();
+        if label == "pet" {
+            if let Some(monitor) = monitor.as_ref() {
+                let monitor_pos = monitor.position();
+                if monitor_pos.x != 0 || monitor_pos.y != 0 {
+                    let inner = window.inner_position().map_err(|e| e.to_string())?;
+                    let cursor_x = cursor.x - inner.x as f64;
+                    let cursor_y = (cursor.y - inner.y as f64) / scale;
+                    return Ok(zones.iter().any(|r| {
+                        let margin = 160.0;
+                        cursor_x >= r.left - margin
+                            && cursor_x <= r.left + r.width + margin
+                            && cursor_y >= r.top - margin
+                            && cursor_y <= r.top + r.height + margin
+                    }));
+                }
+            }
+        }
+
         let monitor_origin_logical = monitor
             .map(|m| {
                 let s = m.scale_factor().max(1.0);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -62,6 +62,7 @@ struct PetDragState {
     start_window_y: f64,
     current_x: f64,
     current_y: f64,
+    native_drag: bool,
     start_anchor: PetStageAnchor,
 }
 
@@ -1457,6 +1458,11 @@ struct LogicalRect {
     height: f64,
 }
 
+fn monitor_uses_primary_origin(monitor: &tauri::Monitor) -> bool {
+    let pos = monitor.position();
+    pos.x == 0 && pos.y == 0
+}
+
 /// Hit-tests the cursor against a list of logical (CSS px) rects expressed in
 /// the target webview's viewport coordinates. Returns true if the cursor is
 /// inside any rect; used to drive per-zone click-through.
@@ -1484,18 +1490,8 @@ async fn is_cursor_in_window_zones(
         let monitor = window.current_monitor().ok().flatten();
         if label == "pet" {
             if let Some(monitor) = monitor.as_ref() {
-                let monitor_pos = monitor.position();
-                if monitor_pos.x != 0 || monitor_pos.y != 0 {
-                    let inner = window.inner_position().map_err(|e| e.to_string())?;
-                    let cursor_x = cursor.x - inner.x as f64;
-                    let cursor_y = (cursor.y - inner.y as f64) / scale;
-                    return Ok(zones.iter().any(|r| {
-                        let margin = 160.0;
-                        cursor_x >= r.left - margin
-                            && cursor_x <= r.left + r.width + margin
-                            && cursor_y >= r.top - margin
-                            && cursor_y <= r.top + r.height + margin
-                    }));
+                if !monitor_uses_primary_origin(monitor) {
+                    return Ok(true);
                 }
             }
         }
@@ -4267,8 +4263,18 @@ async fn start_pet_drag(
             start_window_y: position.y as f64,
             current_x: position.x as f64,
             current_y: position.y as f64,
+            native_drag: false,
             start_anchor,
         });
+    }
+
+    if window.start_dragging().is_ok() {
+        if let Ok(mut drag) = pet_drag_state().lock() {
+            if let Some(state) = drag.as_mut() {
+                state.native_drag = true;
+            }
+        }
+        return Ok(true);
     }
 
     let app_handle = app.clone();
@@ -4360,6 +4366,12 @@ async fn end_pet_drag(app: tauri::AppHandle) -> Result<Option<PetDragResult>, St
     let mut result_anchor = snap.start_anchor;
 
     if let Some(window) = app.get_webview_window("pet") {
+        if snap.native_drag {
+            if let Ok(position) = window.outer_position() {
+                origin.x = position.x as f64;
+                origin.y = position.y as f64;
+            }
+        }
         if let Ok(size) = window.outer_size() {
             let window_scale = window.scale_factor().unwrap_or(1.0).max(1.0);
             let pet_scale = current_pet_scale_percent(&app);

--- a/src/components/notch/NotchPanel.tsx
+++ b/src/components/notch/NotchPanel.tsx
@@ -1513,7 +1513,7 @@ export function NotchPanel() {
   const stableHostHitboxWidth = expandedHostContentWidth + shellSideExtension * 2 + maxHostSlopX * 2
   const stableHostHitboxHeight = expandedHostPanelHeight + maxHostSlopY
   const islandHidden = !islandEnabled || isPetMode || (!layoutPreview && interaction.isHidden)
-  const hostUsesStableCanvas = !isPetMode && islandEnabled
+  const hostUsesStableCanvas = !isPetMode && islandEnabled && effectivePanelState === 'collapsed'
   const hostTargetHitboxWidth = hostUsesStableCanvas ? stableHostHitboxWidth : hitboxWidth
   const hostTargetHitboxHeight = hostUsesStableCanvas ? stableHostHitboxHeight : hitboxHeight
   const [hostHitboxSize, setHostHitboxSize] = useState(() => ({
@@ -1699,6 +1699,12 @@ export function NotchPanel() {
       return () => { cancelled = true }
     }
 
+    const shrinkingFromStableCanvas = !hostUsesStableCanvas && current.width > next.width
+    if (shrinkingFromStableCanvas) {
+      if (commitHostSize()) resizeNativeHost()
+      return () => { cancelled = true }
+    }
+
     const timer = window.setTimeout(() => {
       if (commitHostSize()) resizeNativeHost()
     }, CLOSE_NATIVE_RESIZE_DELAY_MS * islandAnimationScale)
@@ -1707,7 +1713,7 @@ export function NotchPanel() {
       cancelled = true
       window.clearTimeout(timer)
     }
-  }, [hostTargetHitboxWidth, hostTargetHitboxHeight, effectiveHorizontalOffset, displayMonitor, finishPreparedOpen, islandAnimationScale, isDragging, preparingOpen, requestNativeHostResize, updateHostAnchorOffset])
+  }, [hostTargetHitboxWidth, hostTargetHitboxHeight, hostUsesStableCanvas, effectiveHorizontalOffset, displayMonitor, finishPreparedOpen, islandAnimationScale, isDragging, preparingOpen, requestNativeHostResize, updateHostAnchorOffset])
 
   useEffect(() => {
     if (!isTauri() || displayMonitor !== 'auto' || isDragging) return

--- a/src/test/notchPanel.test.tsx
+++ b/src/test/notchPanel.test.tsx
@@ -242,7 +242,7 @@ describe('NotchPanel island shell', () => {
     }
   })
 
-  it('keeps a stable native host canvas while opening from micro', () => {
+  it('keeps a stable native host canvas while collapsed, then sizes to hitbox on hover', () => {
     vi.useFakeTimers()
     try {
       tauriMocks.resizeNotch.mockImplementation(() => new Promise(() => {}))
@@ -276,8 +276,8 @@ describe('NotchPanel island shell', () => {
       })
 
       expect(useSessionStore.getState().panelState).toBe('hover')
-      expect(hostWidthVar()).toBe('754px')
-      expect(tauriMocks.resizeNotch).toHaveBeenCalledTimes(1)
+      expect(hostWidthVar()).toBe('686px')
+      expect(tauriMocks.resizeNotch).toHaveBeenCalledTimes(2)
     } finally {
       vi.useRealTimers()
     }
@@ -304,7 +304,7 @@ describe('NotchPanel island shell', () => {
 
       render(<NotchPanel />)
 
-      expect(hostWidthVar()).toBe('754px')
+      expect(hostWidthVar()).toBe('686px')
       expect(tauriMocks.resizeNotch).toHaveBeenCalledTimes(1)
 
       fireEvent.pointerLeave(screen.getByRole('region', { name: 'AgentBro' }).parentElement!)
@@ -321,7 +321,7 @@ describe('NotchPanel island shell', () => {
 
       expect(hostWidthVar()).toBe('754px')
       expect(hitboxWidthVar()).toBe('140px')
-      expect(tauriMocks.resizeNotch).toHaveBeenCalledTimes(1)
+      expect(tauriMocks.resizeNotch).toHaveBeenCalledTimes(2)
     } finally {
       vi.useRealTimers()
     }
@@ -511,7 +511,7 @@ describe('NotchPanel island shell', () => {
     fireEvent.pointerMove(dragHandle, { pointerId: 7, clientX: 118, clientY: 2 })
 
     await waitFor(() => {
-      expect(tauriMocks.startNotchDrag).toHaveBeenCalledWith(0, 754, 624, 'auto')
+      expect(tauriMocks.startNotchDrag).toHaveBeenCalledWith(0, 686, 192, 'auto')
     })
     expect(screen.getByRole('region', { name: 'AgentBro' })).toHaveAttribute('data-dragging', 'true')
     expect(screen.getByText('agentbro · Port dynamic island')).toBeInTheDocument()
@@ -1081,7 +1081,7 @@ describe('NotchPanel island shell', () => {
     })
 
     expect(screen.getByRole('region', { name: 'AgentBro' })).toHaveAttribute('data-island-state', 'alert_permission')
-    expect(hostWidthVar()).toBe('724px')
+    expect(hostWidthVar()).toBe('656px')
     expect(hitboxWidthVar()).toBe('656px')
     expect(document.querySelector('.notch-panel__alert-content')).toBeInTheDocument()
     expect(document.querySelector('.notch-panel__overlay')).not.toBeInTheDocument()


### PR DESCRIPTION
## Summary
- 修复灵动岛从 collapsed 到 hover 时 native host 尺寸未及时收缩导致的遮挡问题
- 使用 Tauri 原生窗口拖动改善宠物窗口跨显示器拖动体验
- 对外接屏 pet 窗口保持可交互，避免拖到外接屏后点击穿透失控

## Test Plan
- pnpm test:run
- pnpm build
- cargo check --manifest-path src-tauri/Cargo.toml

## Manual Verification
- 主屏宠物点击正常
- 宠物可流畅拖动到外接屏
- 外接屏宠物点击和切换正常

## Notes
- 已关闭错误基线 PR #18；本 PR 基于最新 dev 分支创建，版本保持 1.1.3。