### PR TITLE
[codex] Sync applied agents after skill pack updates

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5447,6 +5447,7 @@ pub fn run() {
             skills::v2::commands::execute_delete_skill_pack,
             skills::v2::commands::preview_apply_skill_pack,
             skills::v2::commands::execute_apply_skill_pack,
+            skills::v2::commands::execute_sync_skill_pack_to_agents,
             skills::v2::commands::preview_remove_skill_pack_from_agent,
             skills::v2::commands::execute_remove_skill_pack_from_agent,
             skills::v2::commands::preview_remove_skill_from_pack,

--- a/src-tauri/src/skills/v2/commands.rs
+++ b/src-tauri/src/skills/v2/commands.rs
@@ -225,6 +225,14 @@ pub fn execute_apply_skill_pack(
 }
 
 #[tauri::command]
+pub fn execute_sync_skill_pack_to_agents(
+    pack_id: String,
+    target_agents: Option<Vec<String>>,
+) -> Result<SkillPackSyncResult, String> {
+    svc()?.sync_skill_pack_to_agents(&pack_id, target_agents.unwrap_or_default())
+}
+
+#[tauri::command]
 pub fn preview_remove_skill_pack_from_agent(
     pack_id: String,
     agent_id: String,

--- a/src-tauri/src/skills/v2/db.rs
+++ b/src-tauri/src/skills/v2/db.rs
@@ -87,6 +87,10 @@ pub const MIGRATIONS: &[&str] = &[
       name TEXT NOT NULL,
       description TEXT NOT NULL DEFAULT '',
       tags_json TEXT NOT NULL DEFAULT '[]',
+      revision INTEGER NOT NULL DEFAULT 1,
+      last_sync_status TEXT NOT NULL DEFAULT 'synced',
+      last_sync_error TEXT,
+      last_synced_at TEXT,
       created_at TEXT NOT NULL,
       updated_at TEXT NOT NULL
     );
@@ -97,6 +101,16 @@ pub const MIGRATIONS: &[&str] = &[
       sort_order INTEGER NOT NULL DEFAULT 0,
       required INTEGER NOT NULL DEFAULT 1,
       PRIMARY KEY(pack_id, skill_id)
+    );
+
+    CREATE TABLE IF NOT EXISTS skill_pack_agent_syncs (
+      pack_id TEXT NOT NULL REFERENCES skill_packs(id) ON DELETE CASCADE,
+      agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+      synced_revision INTEGER NOT NULL DEFAULT 0,
+      status TEXT NOT NULL DEFAULT 'synced',
+      error TEXT,
+      updated_at TEXT NOT NULL,
+      PRIMARY KEY(pack_id, agent_id)
     );
 
     CREATE TABLE IF NOT EXISTS unmanaged_items (
@@ -148,6 +162,7 @@ pub const MIGRATIONS: &[&str] = &[
 
     CREATE INDEX IF NOT EXISTS idx_skill_targets_agent ON skill_targets(agent_id);
     CREATE INDEX IF NOT EXISTS idx_claims_pack ON skill_target_claims(pack_id);
+    CREATE INDEX IF NOT EXISTS idx_pack_agent_syncs_status ON skill_pack_agent_syncs(pack_id, status);
     CREATE INDEX IF NOT EXISTS idx_issues_type ON diagnosis_issues(issue_type, resolved_at);
     CREATE INDEX IF NOT EXISTS idx_projects_root_path ON projects(root_path);
     "#,
@@ -187,6 +202,7 @@ impl Db {
             conn.execute_batch(sql)
                 .map_err(|e| format!("migration: {}", e))?;
         }
+        ensure_skill_pack_sync_schema(&conn)?;
         // record applied version (idempotent)
         let now = now_iso();
         conn.execute(
@@ -228,6 +244,70 @@ impl Db {
             .map_err(|e| e.to_string())
         })
     }
+}
+
+fn ensure_skill_pack_sync_schema(conn: &Connection) -> Result<(), String> {
+    ensure_column(
+        conn,
+        "skill_packs",
+        "revision",
+        "ALTER TABLE skill_packs ADD COLUMN revision INTEGER NOT NULL DEFAULT 1",
+    )?;
+    ensure_column(
+        conn,
+        "skill_packs",
+        "last_sync_status",
+        "ALTER TABLE skill_packs ADD COLUMN last_sync_status TEXT NOT NULL DEFAULT 'synced'",
+    )?;
+    ensure_column(
+        conn,
+        "skill_packs",
+        "last_sync_error",
+        "ALTER TABLE skill_packs ADD COLUMN last_sync_error TEXT",
+    )?;
+    ensure_column(
+        conn,
+        "skill_packs",
+        "last_synced_at",
+        "ALTER TABLE skill_packs ADD COLUMN last_synced_at TEXT",
+    )?;
+    conn.execute_batch(
+        r#"
+        CREATE TABLE IF NOT EXISTS skill_pack_agent_syncs (
+          pack_id TEXT NOT NULL REFERENCES skill_packs(id) ON DELETE CASCADE,
+          agent_id TEXT NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+          synced_revision INTEGER NOT NULL DEFAULT 0,
+          status TEXT NOT NULL DEFAULT 'synced',
+          error TEXT,
+          updated_at TEXT NOT NULL,
+          PRIMARY KEY(pack_id, agent_id)
+        );
+        CREATE INDEX IF NOT EXISTS idx_pack_agent_syncs_status ON skill_pack_agent_syncs(pack_id, status);
+        "#,
+    )
+    .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn ensure_column(
+    conn: &Connection,
+    table: &str,
+    column: &str,
+    alter_sql: &str,
+) -> Result<(), String> {
+    let mut stmt = conn
+        .prepare(&format!("PRAGMA table_info({table})"))
+        .map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map([], |r| r.get::<_, String>(1))
+        .map_err(|e| e.to_string())?;
+    for row in rows {
+        if row.map_err(|e| e.to_string())? == column {
+            return Ok(());
+        }
+    }
+    conn.execute(alter_sql, []).map_err(|e| e.to_string())?;
+    Ok(())
 }
 
 // ── Settings (key/value in DB, with JSON file mirror) ─────────────

--- a/src-tauri/src/skills/v2/models.rs
+++ b/src-tauri/src/skills/v2/models.rs
@@ -5,7 +5,7 @@
 
 use serde::{Deserialize, Serialize};
 
-pub const SCHEMA_VERSION: i64 = 3;
+pub const SCHEMA_VERSION: i64 = 4;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -24,6 +24,8 @@ pub struct SkillManagerSettings {
     pub startup_scan: bool,
     #[serde(default = "default_true")]
     pub show_unmanaged: bool,
+    #[serde(default = "default_true")]
+    pub auto_sync_skill_packs: bool,
 }
 
 fn default_center_path() -> String {
@@ -55,6 +57,7 @@ impl Default for SkillManagerSettings {
             link_fail_policy: default_link_fail(),
             startup_scan: true,
             show_unmanaged: true,
+            auto_sync_skill_packs: true,
         }
     }
 }
@@ -275,6 +278,10 @@ pub struct AppliedPackSummary {
     pub agent_id: Option<String>,
     pub display_name: Option<String>,
     pub icon_key: Option<String>,
+    pub pack_revision: i64,
+    pub synced_revision: i64,
+    pub sync_status: String,
+    pub sync_error: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -287,6 +294,10 @@ pub struct SkillPackSummary {
     pub member_count: usize,
     pub applied_agent_count: usize,
     pub healthy: bool,
+    pub revision: i64,
+    pub sync_status: String,
+    pub pending_sync_count: usize,
+    pub failed_sync_count: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -298,6 +309,10 @@ pub struct SkillPackDetail {
     pub tags: Vec<String>,
     pub members: Vec<PackMember>,
     pub applied_agents: Vec<AppliedPackSummary>,
+    pub revision: i64,
+    pub sync_status: String,
+    pub pending_sync_count: usize,
+    pub failed_sync_count: usize,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -506,6 +521,25 @@ pub struct RemoveSkillFromPackPreview {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct SkillPackSyncAgentResult {
+    pub agent_id: String,
+    pub display_name: String,
+    pub status: String,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SkillPackSyncResult {
+    pub pack_id: String,
+    pub pack_name: String,
+    pub revision: i64,
+    pub status: String,
+    pub agents: Vec<SkillPackSyncAgentResult>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct UnmanagedItemDto {
     pub id: String,
     pub item_type: String,
@@ -597,4 +631,5 @@ pub struct SettingsUpdate {
     pub link_fail_policy: Option<String>,
     pub startup_scan: Option<bool>,
     pub show_unmanaged: Option<bool>,
+    pub auto_sync_skill_packs: Option<bool>,
 }

--- a/src-tauri/src/skills/v2/service.rs
+++ b/src-tauri/src/skills/v2/service.rs
@@ -108,6 +108,9 @@ impl Service {
             if let Some(v) = update.show_unmanaged {
                 current.show_unmanaged = v;
             }
+            if let Some(v) = update.auto_sync_skill_packs {
+                current.auto_sync_skill_packs = v;
+            }
             normalize_shared_agents_center_path(&self.home, &mut current);
             let val = serde_json::to_value(&current).map_err(|e| e.to_string())?;
             db::save_settings_json(c, &val)?;
@@ -3279,7 +3282,7 @@ impl Service {
     pub fn list_skill_packs(&self) -> Result<Vec<SkillPackSummary>, String> {
         let packs = self.db.with_conn(|c| {
             let mut stmt = c
-                .prepare("SELECT id, name, description, tags_json FROM skill_packs WHERE id <> ?1 ORDER BY name COLLATE NOCASE")
+                .prepare("SELECT id, name, description, tags_json, revision FROM skill_packs WHERE id <> ?1 ORDER BY name COLLATE NOCASE")
                 .map_err(|e| e.to_string())?;
             let rows = stmt
                 .query_map([DEFAULT_SKILL_PACK_ID], |r| {
@@ -3288,6 +3291,7 @@ impl Service {
                         name: r.get(1)?,
                         description: r.get(2)?,
                         tags_json: r.get(3)?,
+                        revision: r.get(4)?,
                     })
                 })
                 .map_err(|e| e.to_string())?;
@@ -3302,6 +3306,7 @@ impl Service {
             let member_count = self.pack_member_count(&p.id)?;
             let applied_agent_count = self.pack_applied_agent_count(&p.id)?;
             let healthy = self.pack_members_healthy(&p.id)?;
+            let sync = self.pack_sync_rollup(&p.id, p.revision)?;
             let tags: Vec<String> = serde_json::from_str(&p.tags_json).unwrap_or_default();
             out.push(SkillPackSummary {
                 id: p.id,
@@ -3311,6 +3316,10 @@ impl Service {
                 member_count,
                 applied_agent_count,
                 healthy,
+                revision: p.revision,
+                sync_status: sync.status,
+                pending_sync_count: sync.pending_count,
+                failed_sync_count: sync.failed_count,
             });
         }
         Ok(out)
@@ -3325,6 +3334,10 @@ impl Service {
             member_count: self.center_skill_count()?,
             applied_agent_count: self.pack_applied_agent_count(DEFAULT_SKILL_PACK_ID)?,
             healthy: true,
+            revision: 1,
+            sync_status: "synced".to_string(),
+            pending_sync_count: 0,
+            failed_sync_count: 0,
         })
     }
 
@@ -3390,21 +3403,26 @@ impl Service {
                 tags: Vec::new(),
                 members: self.pack_members(DEFAULT_SKILL_PACK_ID)?,
                 applied_agents: self.pack_applied_agents(DEFAULT_SKILL_PACK_ID)?,
+                revision: 1,
+                sync_status: "synced".to_string(),
+                pending_sync_count: 0,
+                failed_sync_count: 0,
                 created_at: String::new(),
                 updated_at: String::new(),
             });
         }
         let row = self.db.with_conn(|c| {
             c.query_row(
-                "SELECT id, name, description, tags_json, created_at, updated_at FROM skill_packs WHERE id = ?1",
+                "SELECT id, name, description, tags_json, revision, created_at, updated_at FROM skill_packs WHERE id = ?1",
                 params![pack_id],
                 |r| Ok(PackDetailRow {
                     id: r.get(0)?,
                     name: r.get(1)?,
                     description: r.get(2)?,
                     tags_json: r.get(3)?,
-                    created_at: r.get(4)?,
-                    updated_at: r.get(5)?,
+                    revision: r.get(4)?,
+                    created_at: r.get(5)?,
+                    updated_at: r.get(6)?,
                 }),
             )
             .optional()
@@ -3414,6 +3432,7 @@ impl Service {
 
         let members = self.pack_members(&row.id)?;
         let applied = self.pack_applied_agents(&row.id)?;
+        let sync = self.pack_sync_rollup(&row.id, row.revision)?;
         let tags: Vec<String> = serde_json::from_str(&row.tags_json).unwrap_or_default();
         Ok(SkillPackDetail {
             id: row.id,
@@ -3422,6 +3441,10 @@ impl Service {
             tags,
             members,
             applied_agents: applied,
+            revision: row.revision,
+            sync_status: sync.status,
+            pending_sync_count: sync.pending_count,
+            failed_sync_count: sync.failed_count,
             created_at: row.created_at,
             updated_at: row.updated_at,
         })
@@ -3503,17 +3526,124 @@ impl Service {
         let pack_name = self
             .pack_name(pack_id)
             .unwrap_or_else(|_| pack_id.to_string());
+        let pack_revision = self.pack_revision(pack_id).unwrap_or(1);
         Ok(agents
             .into_iter()
-            .map(|agent_id| AppliedPackSummary {
-                pack_id: pack_id.to_string(),
-                pack_name: pack_name.clone(),
-                member_count,
-                agent_id: Some(agent_id.clone()),
-                display_name: Some(agent_meta::display_name(&agent_id)),
-                icon_key: Some(agent_meta::icon_key(&agent_id)),
+            .map(|agent_id| {
+                let state = self
+                    .pack_agent_sync_state(pack_id, &agent_id, pack_revision)
+                    .unwrap_or_else(|_| PackAgentSyncState {
+                        synced_revision: pack_revision,
+                        status: "synced".to_string(),
+                        error: None,
+                    });
+                AppliedPackSummary {
+                    pack_id: pack_id.to_string(),
+                    pack_name: pack_name.clone(),
+                    member_count,
+                    agent_id: Some(agent_id.clone()),
+                    display_name: Some(agent_meta::display_name(&agent_id)),
+                    icon_key: Some(agent_meta::icon_key(&agent_id)),
+                    pack_revision,
+                    synced_revision: state.synced_revision,
+                    sync_status: state.status,
+                    sync_error: state.error,
+                }
             })
             .collect())
+    }
+
+    fn pack_revision(&self, pack_id: &str) -> Result<i64, String> {
+        if pack_id == DEFAULT_SKILL_PACK_ID {
+            return Ok(1);
+        }
+        self.db.with_conn(|c| {
+            c.query_row(
+                "SELECT revision FROM skill_packs WHERE id = ?1",
+                params![pack_id],
+                |r| r.get::<_, i64>(0),
+            )
+            .map_err(|e| e.to_string())
+        })
+    }
+
+    fn pack_sync_rollup(&self, pack_id: &str, revision: i64) -> Result<PackSyncRollup, String> {
+        let agents = self.pack_applied_agent_ids(pack_id)?;
+        let mut pending_count = 0usize;
+        let mut failed_count = 0usize;
+        let mut synced_count = 0usize;
+        for agent_id in &agents {
+            let state = self.pack_agent_sync_state(pack_id, agent_id, revision)?;
+            match state.status.as_str() {
+                "failed" => failed_count += 1,
+                "synced" if state.synced_revision >= revision => synced_count += 1,
+                _ => pending_count += 1,
+            }
+        }
+        let status = if agents.is_empty() || synced_count == agents.len() {
+            "synced"
+        } else if failed_count > 0 && synced_count > 0 {
+            "partial"
+        } else if failed_count > 0 {
+            "failed"
+        } else {
+            "pending"
+        }
+        .to_string();
+        Ok(PackSyncRollup {
+            status,
+            pending_count,
+            failed_count,
+        })
+    }
+
+    fn pack_agent_sync_state(
+        &self,
+        pack_id: &str,
+        agent_id: &str,
+        revision: i64,
+    ) -> Result<PackAgentSyncState, String> {
+        let row = self.db.with_conn(|c| {
+            c.query_row(
+                "SELECT synced_revision, status, error FROM skill_pack_agent_syncs
+                 WHERE pack_id = ?1 AND agent_id = ?2",
+                params![pack_id, agent_id],
+                |r| {
+                    Ok(PackAgentSyncState {
+                        synced_revision: r.get(0)?,
+                        status: r.get(1)?,
+                        error: r.get(2)?,
+                    })
+                },
+            )
+            .optional()
+            .map_err(|e| e.to_string())
+        })?;
+        Ok(row.unwrap_or_else(|| PackAgentSyncState {
+            synced_revision: revision,
+            status: "synced".to_string(),
+            error: None,
+        }))
+    }
+
+    fn pack_applied_agent_ids(&self, pack_id: &str) -> Result<Vec<String>, String> {
+        self.db.with_conn(|c| {
+            let mut stmt = c
+                .prepare(
+                    "SELECT DISTINCT t.agent_id FROM skill_target_claims c
+                     JOIN skill_targets t ON t.id = c.target_id WHERE c.pack_id = ?1
+                     ORDER BY t.agent_id",
+                )
+                .map_err(|e| e.to_string())?;
+            let rows = stmt
+                .query_map([pack_id], |r| r.get::<_, String>(0))
+                .map_err(|e| e.to_string())?;
+            let mut agents = Vec::new();
+            for row in rows {
+                agents.push(row.map_err(|e| e.to_string())?);
+            }
+            Ok(agents)
+        })
     }
 
     fn pack_name(&self, pack_id: &str) -> Result<String, String> {
@@ -3737,19 +3867,49 @@ impl Service {
                 return Err(format!("Pack member '{}' is not in the center library.", m));
             }
         }
+        let existing = if pack.id.is_empty() {
+            None
+        } else {
+            self.db.with_conn(|c| {
+                c.query_row(
+                    "SELECT revision FROM skill_packs WHERE id = ?1",
+                    params![pack.id],
+                    |r| r.get::<_, i64>(0),
+                )
+                .optional()
+                .map_err(|e| e.to_string())
+            })?
+        };
+        let old_revision = existing.unwrap_or(0);
+        let old_members = if existing.is_some() {
+            self.pack_member_skill_ids(&pack.id)?
+        } else {
+            Vec::new()
+        };
+        let member_changed = existing.is_some() && old_members != pack.skill_ids;
+        let applied_agents = if member_changed {
+            self.pack_applied_agent_ids(&pack.id)?
+        } else {
+            Vec::new()
+        };
         let id = if pack.id.is_empty() {
             format!("pack-{}", uuid_short())
         } else {
             pack.id.clone()
         };
+        let next_revision = if member_changed {
+            old_revision + 1
+        } else {
+            existing.unwrap_or(1).max(1)
+        };
         let now = db::now_iso();
         let tags_json = serde_json::to_string(&pack.tags).map_err(|e| e.to_string())?;
         self.db.transaction(|tx| {
             tx.execute(
-                "INSERT INTO skill_packs(id, name, description, tags_json, created_at, updated_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?5)
-                 ON CONFLICT(id) DO UPDATE SET name = excluded.name, description = excluded.description, tags_json = excluded.tags_json, updated_at = excluded.updated_at",
-                params![id, pack.name, pack.description, tags_json, now],
+                "INSERT INTO skill_packs(id, name, description, tags_json, revision, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?6)
+                 ON CONFLICT(id) DO UPDATE SET name = excluded.name, description = excluded.description, tags_json = excluded.tags_json, revision = excluded.revision, updated_at = excluded.updated_at",
+                params![id, pack.name, pack.description, tags_json, next_revision, now],
             )
             .map_err(|e| e.to_string())?;
             tx.execute(
@@ -3767,6 +3927,14 @@ impl Service {
             }
             Ok(())
         })?;
+        if member_changed && !applied_agents.is_empty() {
+            self.mark_pack_agents_pending(&id, &applied_agents, old_revision)?;
+            if self.settings()?.auto_sync_skill_packs {
+                let _ = self.sync_skill_pack_to_agents(&id, applied_agents);
+            } else {
+                self.update_pack_rollup_status(&id, next_revision)?;
+            }
+        }
         let detail = self.get_skill_pack_detail(&id)?;
         self.refresh_snapshot_best_effort();
         Ok(detail)
@@ -3790,6 +3958,194 @@ impl Service {
         })?;
         self.refresh_snapshot_best_effort();
         Ok(())
+    }
+
+    pub fn sync_skill_pack_to_agents(
+        &self,
+        pack_id: &str,
+        target_agents: Vec<String>,
+    ) -> Result<SkillPackSyncResult, String> {
+        let pack_name = self.pack_name(pack_id)?;
+        let revision = self.pack_revision(pack_id)?;
+        let agents = if target_agents.is_empty() {
+            self.pack_applied_agent_ids(pack_id)?
+        } else {
+            target_agents
+        };
+        let mut results = Vec::new();
+        for agent_id in agents {
+            self.mark_pack_agent_status(pack_id, &agent_id, revision, "syncing", None)?;
+            match self.sync_skill_pack_to_agent(pack_id, &agent_id) {
+                Ok(()) => {
+                    self.mark_pack_agent_status(pack_id, &agent_id, revision, "synced", None)?;
+                    results.push(SkillPackSyncAgentResult {
+                        agent_id: agent_id.clone(),
+                        display_name: agent_meta::display_name(&agent_id),
+                        status: "synced".to_string(),
+                        error: None,
+                    });
+                }
+                Err(error) => {
+                    self.mark_pack_agent_status(
+                        pack_id,
+                        &agent_id,
+                        revision.saturating_sub(1),
+                        "failed",
+                        Some(&error),
+                    )?;
+                    results.push(SkillPackSyncAgentResult {
+                        agent_id: agent_id.clone(),
+                        display_name: agent_meta::display_name(&agent_id),
+                        status: "failed".to_string(),
+                        error: Some(error),
+                    });
+                }
+            }
+        }
+        let status = self.update_pack_rollup_status(pack_id, revision)?;
+        self.refresh_snapshot_best_effort();
+        Ok(SkillPackSyncResult {
+            pack_id: pack_id.to_string(),
+            pack_name,
+            revision,
+            status,
+            agents: results,
+        })
+    }
+
+    fn sync_skill_pack_to_agent(&self, pack_id: &str, agent_id: &str) -> Result<(), String> {
+        let member_ids = self.pack_member_skill_ids(pack_id)?;
+        let member_set: BTreeSet<String> = member_ids.iter().cloned().collect();
+        let stale_targets: Vec<(String, String)> = self.db.with_conn(|c| {
+            let mut stmt = c
+                .prepare(
+                    "SELECT DISTINCT t.id, t.skill_id FROM skill_target_claims c
+                     JOIN skill_targets t ON t.id = c.target_id
+                     WHERE c.pack_id = ?1 AND t.agent_id = ?2",
+                )
+                .map_err(|e| e.to_string())?;
+            let rows = stmt
+                .query_map(params![pack_id, agent_id], |r| {
+                    Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
+                })
+                .map_err(|e| e.to_string())?;
+            let mut out = Vec::new();
+            for row in rows {
+                let (target_id, skill_id) = row.map_err(|e| e.to_string())?;
+                if !member_set.contains(&skill_id) {
+                    out.push((target_id, skill_id));
+                }
+            }
+            Ok(out)
+        })?;
+
+        for (target_id, _) in stale_targets {
+            self.db.with_conn(|c| {
+                c.execute(
+                    "DELETE FROM skill_target_claims WHERE target_id = ?1 AND pack_id = ?2",
+                    params![target_id, pack_id],
+                )
+                .map_err(|e| e.to_string())
+            })?;
+            if self.count_claims(&target_id)? == 0 {
+                self.remove_target_completely(&target_id)?;
+            }
+        }
+
+        if member_ids.is_empty() {
+            self.scan_one_agent_into_db(agent_id)?;
+            return Ok(());
+        }
+
+        let result = self.apply_skill_pack_with_decisions(
+            pack_id,
+            vec![agent_id.to_string()],
+            self.settings()?.default_distribute_mode,
+            Vec::new(),
+        )?;
+        if !result.blockers.is_empty() {
+            return Err(format!(
+                "{} blocker(s) need manual resolution before syncing.",
+                result.blockers.len()
+            ));
+        }
+        Ok(())
+    }
+
+    fn mark_pack_agents_pending(
+        &self,
+        pack_id: &str,
+        agent_ids: &[String],
+        synced_revision: i64,
+    ) -> Result<(), String> {
+        for agent_id in agent_ids {
+            self.mark_pack_agent_status(pack_id, agent_id, synced_revision, "pending", None)?;
+        }
+        Ok(())
+    }
+
+    fn mark_pack_agents_synced(
+        &self,
+        pack_id: &str,
+        agent_ids: &[String],
+        synced_revision: i64,
+    ) -> Result<(), String> {
+        for agent_id in agent_ids {
+            self.mark_pack_agent_status(pack_id, agent_id, synced_revision, "synced", None)?;
+        }
+        Ok(())
+    }
+
+    fn mark_pack_agent_status(
+        &self,
+        pack_id: &str,
+        agent_id: &str,
+        synced_revision: i64,
+        status: &str,
+        error: Option<&str>,
+    ) -> Result<(), String> {
+        let now = db::now_iso();
+        self.db.with_conn(|c| {
+            c.execute(
+                "INSERT INTO skill_pack_agent_syncs(pack_id, agent_id, synced_revision, status, error, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+                 ON CONFLICT(pack_id, agent_id) DO UPDATE SET
+                   synced_revision = excluded.synced_revision,
+                   status = excluded.status,
+                   error = excluded.error,
+                   updated_at = excluded.updated_at",
+                params![pack_id, agent_id, synced_revision, status, error, now],
+            )
+            .map_err(|e| e.to_string())?;
+            Ok(())
+        })
+    }
+
+    fn update_pack_rollup_status(&self, pack_id: &str, revision: i64) -> Result<String, String> {
+        let rollup = self.pack_sync_rollup(pack_id, revision)?;
+        let now = db::now_iso();
+        let error = if rollup.failed_count > 0 {
+            Some(format!("{} agent(s) failed to sync.", rollup.failed_count))
+        } else {
+            None
+        };
+        self.db.with_conn(|c| {
+            c.execute(
+                "UPDATE skill_packs SET last_sync_status = ?1, last_sync_error = ?2, last_synced_at = ?3 WHERE id = ?4",
+                params![rollup.status, error, now, pack_id],
+            )
+            .map_err(|e| e.to_string())?;
+            Ok(())
+        })?;
+        Ok(rollup.status)
+    }
+
+    fn pack_member_skill_ids(&self, pack_id: &str) -> Result<Vec<String>, String> {
+        Ok(self
+            .pack_members(pack_id)?
+            .into_iter()
+            .map(|member| member.skill_id)
+            .collect())
     }
 
     pub fn apply_skill_pack(
@@ -3816,7 +4172,14 @@ impl Service {
         if !preview.blockers.is_empty() && preview.blocker_decisions.is_empty() {
             return Ok(preview);
         }
-        self.execute_distribute_skill(preview, ClaimOrigin::Pack(pack_id.to_string()))
+        let result =
+            self.execute_distribute_skill(preview, ClaimOrigin::Pack(pack_id.to_string()))?;
+        if pack_id != DEFAULT_SKILL_PACK_ID && result.blockers.is_empty() {
+            let revision = self.pack_revision(pack_id)?;
+            self.mark_pack_agents_synced(pack_id, &result.target_agents, revision)?;
+            self.update_pack_rollup_status(pack_id, revision)?;
+        }
+        Ok(result)
     }
 
     /// Revoke a pack from an agent: remove only the pack's claims; delete the
@@ -4056,6 +4419,14 @@ impl Service {
         for pid in pack_ids {
             let name = self.pack_name(&pid).unwrap_or_else(|_| pid.clone());
             let member_count = self.pack_member_count(&pid).unwrap_or(0);
+            let pack_revision = self.pack_revision(&pid).unwrap_or(1);
+            let state = self
+                .pack_agent_sync_state(&pid, agent_id, pack_revision)
+                .unwrap_or_else(|_| PackAgentSyncState {
+                    synced_revision: pack_revision,
+                    status: "synced".to_string(),
+                    error: None,
+                });
             out.push(AppliedPackSummary {
                 pack_id: pid,
                 pack_name: name,
@@ -4063,6 +4434,10 @@ impl Service {
                 agent_id: None,
                 display_name: None,
                 icon_key: None,
+                pack_revision,
+                synced_revision: state.synced_revision,
+                sync_status: state.status,
+                sync_error: state.error,
             });
         }
         Ok(out)
@@ -4297,14 +4672,28 @@ struct PackRow {
     name: String,
     description: String,
     tags_json: String,
+    revision: i64,
 }
 struct PackDetailRow {
     id: String,
     name: String,
     description: String,
     tags_json: String,
+    revision: i64,
     created_at: String,
     updated_at: String,
+}
+
+struct PackSyncRollup {
+    status: String,
+    pending_count: usize,
+    failed_count: usize,
+}
+
+struct PackAgentSyncState {
+    synced_revision: i64,
+    status: String,
+    error: Option<String>,
 }
 
 // I had a bug: TargetRow query in get_agent_detail selects skill_id at col 1

--- a/src-tauri/src/skills/v2/tests.rs
+++ b/src-tauri/src/skills/v2/tests.rs
@@ -1136,6 +1136,128 @@ fn apply_pack_is_idempotent() {
 }
 
 #[test]
+fn updating_applied_pack_auto_syncs_new_members_by_default() {
+    let (_home, svc, _lock) = fresh_service("pack-auto-sync");
+    let first = write_skill(&svc.home.join("s"), "one", "skill-one", Some("v1"));
+    let second = write_skill(&svc.home.join("s"), "two", "skill-two", Some("v1"));
+    for src in [first, second] {
+        svc.execute_add_center_skill(
+            AddCenterSkillInput {
+                source_path: src.display().to_string(),
+                source_type: "local_folder".to_string(),
+                source_uri: None,
+                imported_from_agent: None,
+                imported_from_path: None,
+                multi: None,
+                import_mode: None,
+            },
+            vec![],
+        )
+        .unwrap();
+    }
+    svc.upsert_skill_pack(UpsertPackInput {
+        id: "p-sync".to_string(),
+        name: "Sync".to_string(),
+        description: "".to_string(),
+        tags: vec![],
+        skill_ids: vec!["skill-one".to_string()],
+    })
+    .unwrap();
+    svc.apply_skill_pack("p-sync", vec!["codex".to_string()], "copy".to_string())
+        .unwrap();
+
+    let updated = svc
+        .upsert_skill_pack(UpsertPackInput {
+            id: "p-sync".to_string(),
+            name: "Sync".to_string(),
+            description: "".to_string(),
+            tags: vec![],
+            skill_ids: vec!["skill-one".to_string(), "skill-two".to_string()],
+        })
+        .unwrap();
+
+    assert_eq!(updated.sync_status, "synced");
+    assert_eq!(updated.pending_sync_count, 0);
+    let second_detail = svc.get_skill_detail("skill-two").unwrap();
+    assert!(second_detail.targets.iter().any(|target| {
+        target.agent_id == "codex"
+            && target
+                .claims
+                .iter()
+                .any(|claim| claim.pack_id.as_deref() == Some("p-sync"))
+    }));
+}
+
+#[test]
+fn updating_applied_pack_can_defer_and_manually_sync() {
+    let (_home, svc, _lock) = fresh_service("pack-manual-sync");
+    svc.update_settings(SettingsUpdate {
+        center_path: None,
+        sqlite_path: None,
+        default_distribute_mode: None,
+        link_fail_policy: None,
+        startup_scan: None,
+        show_unmanaged: None,
+        auto_sync_skill_packs: Some(false),
+    })
+    .unwrap();
+    let first = write_skill(&svc.home.join("s"), "one", "skill-one", Some("v1"));
+    let second = write_skill(&svc.home.join("s"), "two", "skill-two", Some("v1"));
+    for src in [first, second] {
+        svc.execute_add_center_skill(
+            AddCenterSkillInput {
+                source_path: src.display().to_string(),
+                source_type: "local_folder".to_string(),
+                source_uri: None,
+                imported_from_agent: None,
+                imported_from_path: None,
+                multi: None,
+                import_mode: None,
+            },
+            vec![],
+        )
+        .unwrap();
+    }
+    svc.upsert_skill_pack(UpsertPackInput {
+        id: "p-manual".to_string(),
+        name: "Manual".to_string(),
+        description: "".to_string(),
+        tags: vec![],
+        skill_ids: vec!["skill-one".to_string()],
+    })
+    .unwrap();
+    svc.apply_skill_pack("p-manual", vec!["codex".to_string()], "copy".to_string())
+        .unwrap();
+
+    let pending = svc
+        .upsert_skill_pack(UpsertPackInput {
+            id: "p-manual".to_string(),
+            name: "Manual".to_string(),
+            description: "".to_string(),
+            tags: vec![],
+            skill_ids: vec!["skill-one".to_string(), "skill-two".to_string()],
+        })
+        .unwrap();
+
+    assert_eq!(pending.sync_status, "pending");
+    assert_eq!(pending.pending_sync_count, 1);
+    assert!(svc
+        .get_skill_detail("skill-two")
+        .unwrap()
+        .targets
+        .is_empty());
+
+    let result = svc
+        .sync_skill_pack_to_agents("p-manual", vec!["codex".to_string()])
+        .unwrap();
+    assert_eq!(result.status, "synced");
+    let synced = svc.get_skill_pack_detail("p-manual").unwrap();
+    assert_eq!(synced.sync_status, "synced");
+    assert_eq!(synced.pending_sync_count, 0);
+    assert_eq!(svc.get_skill_detail("skill-two").unwrap().targets.len(), 1);
+}
+
+#[test]
 fn apply_pack_accepts_blocker_decisions_for_unmanaged_targets() {
     let (_home, svc, _lock) = fresh_service("pack-blocker-decisions");
     let src = write_skill(
@@ -2628,6 +2750,7 @@ fn settings_round_trip() {
             link_fail_policy: Some("copy".to_string()),
             startup_scan: Some(false),
             show_unmanaged: None,
+            auto_sync_skill_packs: None,
         })
         .unwrap();
     assert_eq!(updated.default_distribute_mode, "copy");
@@ -2642,6 +2765,7 @@ fn settings_round_trip() {
             link_fail_policy: None,
             startup_scan: None,
             show_unmanaged: None,
+            auto_sync_skill_packs: None,
         })
         .unwrap();
     assert!(migrated.center_path.ends_with(".agentbro/skills"));

--- a/src/components/skills-v2/SettingsPageV2.tsx
+++ b/src/components/skills-v2/SettingsPageV2.tsx
@@ -127,6 +127,21 @@ export function SettingsPageV2() {
         </div>
 
         <div className="sm2__issue">
+          <h4 className="sm2__settings-label">{t('skills.packAutoSyncTitle', { defaultValue: '技能包同步' })}</h4>
+          <label className="sm2__checkbox-row">
+            <input
+              type="checkbox"
+              checked={settings.autoSyncSkillPacks !== false}
+              onChange={(e) => update({ autoSyncSkillPacks: e.target.checked })}
+            />
+            {t('skills.packAutoSyncLabel', { defaultValue: '技能包更新后自动同步到已应用的 Agent' })}
+          </label>
+          <p className="sm2__settings-help">
+            {t('skills.packAutoSyncHelp', { defaultValue: '关闭后，技能包页面会显示有变更未同步，并提供手动同步按钮。' })}
+          </p>
+        </div>
+
+        <div className="sm2__issue">
           <h4 className="sm2__settings-label">SQLite / JSON 快照</h4>
           <div className="sm2__detail-meta">
             <div>SQLite：{settings.sqlitePath}</div>

--- a/src/components/skills-v2/SkillPackPage.tsx
+++ b/src/components/skills-v2/SkillPackPage.tsx
@@ -32,6 +32,7 @@ function isManagedCopyBlocker(blocker: ConflictBlocker) {
 }
 
 export function SkillPackPage() {
+  const { t } = useTranslation()
   const state = useSkillStoreV2()
   const [packQuery, setPackQuery] = useState('')
   const [builderMode, setBuilderMode] = useState<BuilderMode | null>(null)
@@ -40,6 +41,7 @@ export function SkillPackPage() {
   const [removeSkillPreview, setRemoveSkillPreview] = useState<RemoveSkillFromPackPreview | null>(null)
   const [revokePreview, setRevokePreview] = useState<RemovePackFromAgentPreview | null>(null)
   const [busy, setBusy] = useState(false)
+  const [syncNotice, setSyncNotice] = useState<string | null>(null)
 
   useEffect(() => {
     state.loadOverview()
@@ -68,6 +70,7 @@ export function SkillPackPage() {
   const totalMembers = state.packs.reduce((sum, pack) => sum + pack.memberCount, 0)
   const totalApplied = state.packs.reduce((sum, pack) => sum + pack.appliedAgentCount, 0)
   const unhealthyPacks = state.packs.filter((pack) => !pack.healthy).length
+  const syncIssueCount = state.packs.reduce((sum, pack) => sum + (pack.pendingSyncCount || 0) + (pack.failedSyncCount || 0), 0)
 
   const startCreate = () => {
     state.selectPack(null)
@@ -110,6 +113,26 @@ export function SkillPackPage() {
     }
   }
 
+  const syncPack = async (packId: string, agentIds: string[] = []) => {
+    setBusy(true)
+    setSyncNotice(null)
+    try {
+      const result = await skillApiV2.syncPackToAgents(packId, agentIds)
+      const failed = result.agents.filter((agent) => agent.status === 'failed').length
+      setSyncNotice(
+        failed > 0
+          ? t('skills.packSyncFailedNotice', { count: failed, defaultValue: '{{count}} 个 Agent 同步失败，可查看状态后重试。' })
+          : t('skills.packSyncDoneNotice', { count: result.agents.length, defaultValue: '已同步 {{count}} 个 Agent。' }),
+      )
+      await state.loadOverview(true)
+      await state.selectPack(packId)
+    } catch (e) {
+      state.setError(String(e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
   return (
     <div className="sm2 sm2--packs sm2--packs-redesign">
       <div className="sm2__header sm2__header--stacked">
@@ -126,12 +149,13 @@ export function SkillPackPage() {
       </div>
 
       {state.error && <div className="sm2__error">{state.error}</div>}
+      {syncNotice && <div className="sm2__notice sm2__notice--ok">{syncNotice}</div>}
 
       <div className="sm2__pack-dashboard">
         <PackMetric label="技能包" value={state.packs.length} />
         <PackMetric label="成员引用" value={totalMembers} />
         <PackMetric label="Agent 应用" value={totalApplied} />
-        <PackMetric label="需要处理" value={unhealthyPacks + missingCount} tone={unhealthyPacks + missingCount > 0 ? 'warn' : 'ok'} />
+        <PackMetric label="需要处理" value={unhealthyPacks + missingCount + syncIssueCount} tone={unhealthyPacks + missingCount + syncIssueCount > 0 ? 'warn' : 'ok'} />
       </div>
 
       <div className="sm2__pack-layout">
@@ -185,6 +209,7 @@ export function SkillPackPage() {
               onDelete={() => openDelete(detail.id)}
               onRemoveSkill={(skillId) => openRemoveSkill(detail.id, skillId)}
               onRevoke={(agentId) => openRevoke(detail.id, agentId)}
+              onSync={(agentIds) => syncPack(detail.id, agentIds)}
             />
           )}
         </main>
@@ -337,18 +362,21 @@ function PackListItem({
   onClick: () => void
 }) {
   const isDefault = pack.id === DEFAULT_SKILL_PACK_ID
+  const syncStatus = pack.syncStatus || 'synced'
+  const hasSyncIssue = (pack.pendingSyncCount || 0) + (pack.failedSyncCount || 0) > 0
   return (
     <button className={`sm2__pack-list-item${active ? ' sm2__pack-list-item--active' : ''}${isDefault ? ' sm2__pack-list-item--default' : ''}`} onClick={onClick}>
       <span className="sm2__pack-list-top">
         <strong>{pack.name}</strong>
-        <span className={`sm2__pack-health ${pack.healthy ? 'sm2__pack-health--ok' : 'sm2__pack-health--warn'}`}>
-          {isDefault ? '系统' : pack.healthy ? 'OK' : '缺失'}
+        <span className={`sm2__pack-health ${pack.healthy && !hasSyncIssue ? 'sm2__pack-health--ok' : 'sm2__pack-health--warn'}`}>
+          {isDefault ? '系统' : hasSyncIssue ? packSyncStatusLabel(syncStatus) : pack.healthy ? 'OK' : '缺失'}
         </span>
       </span>
       <span className="sm2__pack-list-desc">{pack.description || '自定义 Skill 组合'}</span>
       <span className="sm2__pack-list-meta">
         <span>{pack.memberCount} Skills</span>
         <span>{pack.appliedAgentCount} Agents</span>
+        {hasSyncIssue && <span>{(pack.pendingSyncCount || 0) + (pack.failedSyncCount || 0)} 待同步</span>}
       </span>
     </button>
   )
@@ -374,6 +402,7 @@ function PackDetail({
   onDelete,
   onRemoveSkill,
   onRevoke,
+  onSync,
 }: {
   detail: SkillPackDetail
   busy: boolean
@@ -383,9 +412,12 @@ function PackDetail({
   onDelete: () => void
   onRemoveSkill: (skillId: string) => void
   onRevoke: (agentId: string) => void
+  onSync: (agentIds?: string[]) => void
 }) {
   const missing = detail.members.filter((member) => member.missing)
   const isDefault = detail.id === DEFAULT_SKILL_PACK_ID
+  const syncStatus = detail.syncStatus || 'synced'
+  const needsSync = packNeedsSync(detail)
   return (
     <div className="sm2__pack-workbench">
       <header className="sm2__pack-detail-hero">
@@ -409,6 +441,11 @@ function PackDetail({
             应用
           </button>
           {!isDefault && <button className="sm2__btn" onClick={onEdit} disabled={busy}>编辑</button>}
+          {!isDefault && needsSync && (
+            <button className="sm2__btn sm2__btn--primary" onClick={() => onSync()} disabled={busy}>
+              {busy ? '同步中…' : '同步到 Agent'}
+            </button>
+          )}
           {!isDefault && <button className="sm2__btn" onClick={onDuplicate} disabled={busy}>复制</button>}
           {!isDefault && <button className="sm2__btn sm2__btn--danger" onClick={onDelete} disabled={busy}>删除</button>}
         </div>
@@ -426,10 +463,17 @@ function PackDetail({
         </div>
       )}
 
+      {!isDefault && needsSync && (
+        <div className={`sm2__notice ${syncStatus === 'failed' || syncStatus === 'partial' ? 'sm2__notice--warn' : 'sm2__notice--ok'}`}>
+          {packSyncStatusLabel(syncStatus)}：{detail.pendingSyncCount || 0} 个待同步，{detail.failedSyncCount || 0} 个失败。
+        </div>
+      )}
+
       <div className="sm2__pack-summary-grid">
         <PackMetric label="成员 Skills" value={detail.members.length} />
         <PackMetric label="已应用 Agent" value={detail.appliedAgents.length} />
         <PackMetric label="缺失成员" value={missing.length} tone={missing.length > 0 ? 'warn' : 'ok'} />
+        <PackMetric label="同步状态" value={(detail.pendingSyncCount || 0) + (detail.failedSyncCount || 0)} tone={needsSync ? 'warn' : 'ok'} />
       </div>
 
       <div className="sm2__pack-sections">
@@ -485,8 +529,14 @@ function PackDetail({
                   <AgentIconBadge iconKey={agent.iconKey || agent.agentId || agent.packName} title={agent.displayName || agent.agentId || agent.packName} size={30} />
                   <div>
                     <strong>{agent.displayName || agent.agentId || agent.packName}</strong>
-                    <span>{agent.memberCount} member claims</span>
+                    <span>{agent.memberCount} member claims · {packSyncStatusLabel(agent.syncStatus || 'synced')}</span>
+                    {agent.syncError && <span>{agent.syncError}</span>}
                   </div>
+                  {agent.agentId && agent.syncStatus && agent.syncStatus !== 'synced' && (
+                    <button className="sm2__btn" disabled={busy} onClick={() => onSync([agent.agentId!])}>
+                      同步
+                    </button>
+                  )}
                   {agent.agentId && (
                     <button className="sm2__btn sm2__btn--danger" disabled={busy} onClick={() => onRevoke(agent.agentId!)}>
                       撤销
@@ -500,6 +550,18 @@ function PackDetail({
       </div>
     </div>
   )
+}
+
+function packNeedsSync(pack: Pick<SkillPackDetail, 'pendingSyncCount' | 'failedSyncCount' | 'syncStatus'>) {
+  return (pack.pendingSyncCount || 0) + (pack.failedSyncCount || 0) > 0 || ['pending', 'failed', 'partial', 'syncing'].includes(pack.syncStatus || '')
+}
+
+function packSyncStatusLabel(status: string) {
+  if (status === 'pending') return '有变更未同步'
+  if (status === 'syncing') return '同步中'
+  if (status === 'failed') return '同步失败'
+  if (status === 'partial') return '部分同步'
+  return '已同步'
 }
 
 function PackBuilderPanel({

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -818,7 +818,12 @@
     "fileEmpty": "This file is empty",
     "fileLarge": "Large file ({{size}}) — source view only",
     "frontmatter": "Frontmatter",
-    "frontmatterAdditional": "{{count}} additional fields"
+    "frontmatterAdditional": "{{count}} additional fields",
+    "packAutoSyncTitle": "Skill pack sync",
+    "packAutoSyncLabel": "Automatically sync skill pack updates to applied Agents",
+    "packAutoSyncHelp": "When disabled, pack pages show unsynced changes and provide a manual sync button.",
+    "packSyncFailedNotice": "{{count}} Agent(s) failed to sync. Check the status and retry.",
+    "packSyncDoneNotice": "Synced {{count}} Agent(s)."
   },
   "update": {
     "availableTitle": "Update Available",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -819,7 +819,12 @@
     "fileEmpty": "This file is empty",
     "fileLarge": "Large file ({{size}}) — source view only",
     "frontmatter": "Frontmatter",
-    "frontmatterAdditional": "{{count}} additional fields"
+    "frontmatterAdditional": "{{count}} additional fields",
+    "packAutoSyncTitle": "スキルパック同期",
+    "packAutoSyncLabel": "スキルパック更新後、適用済み Agent に自動同期する",
+    "packAutoSyncHelp": "無効にすると、パックページに未同期の変更が表示され、手動同期ボタンが使えます。",
+    "packSyncFailedNotice": "{{count}} 件の Agent の同期に失敗しました。状態を確認して再試行できます。",
+    "packSyncDoneNotice": "{{count}} 件の Agent を同期しました。"
   },
   "update": {
     "availableTitle": "アップデートがあります",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -819,7 +819,12 @@
     "fileEmpty": "This file is empty",
     "fileLarge": "Large file ({{size}}) — source view only",
     "frontmatter": "Frontmatter",
-    "frontmatterAdditional": "{{count}} additional fields"
+    "frontmatterAdditional": "{{count}} additional fields",
+    "packAutoSyncTitle": "스킬 팩 동기화",
+    "packAutoSyncLabel": "스킬 팩 업데이트 후 적용된 Agent에 자동 동기화",
+    "packAutoSyncHelp": "끄면 팩 페이지에 동기화되지 않은 변경 사항이 표시되고 수동 동기화 버튼이 제공됩니다.",
+    "packSyncFailedNotice": "{{count}}개 Agent 동기화에 실패했습니다. 상태를 확인한 뒤 다시 시도할 수 있습니다.",
+    "packSyncDoneNotice": "{{count}}개 Agent를 동기화했습니다."
   },
   "update": {
     "availableTitle": "업데이트 가능",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -636,7 +636,12 @@
       "targetDirectChild": "Hedef yol '{{targetPath}}', {{skillsDir}} dizininin doğrudan alt öğesi olmalıdır.",
       "targetNoParent": "Hedef yol '{{targetPath}}' için üst dizin yok.",
       "targetNameMismatch": "Hedef yol '{{targetPath}}', Skill '{{skillId}}' ile eşleşmiyor."
-    }
+    },
+    "packAutoSyncTitle": "Skill paketi eşitleme",
+    "packAutoSyncLabel": "Skill paketi güncellemelerini uygulanmış Agentlara otomatik eşitle",
+    "packAutoSyncHelp": "Kapalıyken paket sayfaları eşitlenmemiş değişiklikleri gösterir ve elle eşitleme düğmesi sunar.",
+    "packSyncFailedNotice": "{{count}} Agent eşitlenemedi. Durumu kontrol edip tekrar deneyebilirsiniz.",
+    "packSyncDoneNotice": "{{count}} Agent eşitlendi."
   },
   "update": {
     "availableTitle": "Güncelleme Mevcut",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -859,7 +859,12 @@
     "fileEmpty": "文件为空",
     "fileLarge": "大文件 ({{size}}) — 仅显示源码",
     "frontmatter": "元数据",
-    "frontmatterAdditional": "{{count}} 个附加字段"
+    "frontmatterAdditional": "{{count}} 个附加字段",
+    "packAutoSyncTitle": "技能包同步",
+    "packAutoSyncLabel": "技能包更新后自动同步到已应用的 Agent",
+    "packAutoSyncHelp": "关闭后，技能包页面会显示有变更未同步，并提供手动同步按钮。",
+    "packSyncFailedNotice": "{{count}} 个 Agent 同步失败，可查看状态后重试。",
+    "packSyncDoneNotice": "已同步 {{count}} 个 Agent。"
   },
   "update": {
     "availableTitle": "发现新版本",

--- a/src/services/skillApiV2.ts
+++ b/src/services/skillApiV2.ts
@@ -16,6 +16,7 @@ export interface SkillManagerSettings {
   linkFailPolicy: 'ask' | 'copy'
   startupScan: boolean
   showUnmanaged: boolean
+  autoSyncSkillPacks?: boolean
 }
 
 export interface InstalledAgentRef {
@@ -125,6 +126,10 @@ export interface SkillPackSummary {
   memberCount: number
   appliedAgentCount: number
   healthy: boolean
+  revision?: number
+  syncStatus?: 'synced' | 'pending' | 'syncing' | 'failed' | 'partial' | string
+  pendingSyncCount?: number
+  failedSyncCount?: number
 }
 
 export interface PackMember {
@@ -142,6 +147,10 @@ export interface AppliedPackSummary {
   agentId?: string | null
   displayName?: string | null
   iconKey?: string | null
+  packRevision?: number
+  syncedRevision?: number
+  syncStatus?: 'synced' | 'pending' | 'syncing' | 'failed' | 'partial' | string
+  syncError?: string | null
 }
 
 export interface SkillPackDetail {
@@ -151,6 +160,10 @@ export interface SkillPackDetail {
   tags: string[]
   members: PackMember[]
   appliedAgents: AppliedPackSummary[]
+  revision?: number
+  syncStatus?: 'synced' | 'pending' | 'syncing' | 'failed' | 'partial' | string
+  pendingSyncCount?: number
+  failedSyncCount?: number
   createdAt: string
   updatedAt: string
 }
@@ -391,6 +404,21 @@ export interface RemoveSkillFromPackPreview {
   appliedAgentCount: number
   canKeepStandalone: boolean
   canRemoveTargets: boolean
+}
+
+export interface SkillPackSyncAgentResult {
+  agentId: string
+  displayName: string
+  status: 'synced' | 'failed' | string
+  error: string | null
+}
+
+export interface SkillPackSyncResult {
+  packId: string
+  packName: string
+  revision: number
+  status: 'synced' | 'pending' | 'failed' | 'partial' | string
+  agents: SkillPackSyncAgentResult[]
 }
 
 export interface UnmanagedItemDto {
@@ -720,6 +748,8 @@ export const skillApiV2 = {
     isTauri ? invoke<DistributionPreview>('preview_apply_skill_pack', { packId, targetAgents, requestedMode }) : Promise.resolve({ skillIds: [], targetAgents, requestedMode, changes: [], blockers: [], blockerDecisions: [] }),
   executeApplyPack: (packId: string, targetAgents: string[], requestedMode: 'link' | 'copy', blockerDecisions: DistributionBlockerDecision[] = []) =>
     isTauri ? invoke<DistributionPreview>('execute_apply_skill_pack', { packId, targetAgents, requestedMode, blockerDecisions }) : Promise.resolve({ skillIds: [], targetAgents, requestedMode, changes: [], blockers: [], blockerDecisions }),
+  syncPackToAgents: (packId: string, targetAgents: string[] = []) =>
+    isTauri ? invoke<SkillPackSyncResult>('execute_sync_skill_pack_to_agents', { packId, targetAgents }) : Promise.resolve({ packId, packName: packId, revision: 1, status: 'synced', agents: [] }),
   previewRemovePackFromAgent: (packId: string, agentId: string) =>
     isTauri ? invoke<RemovePackFromAgentPreview>('preview_remove_skill_pack_from_agent', { packId, agentId }) : Promise.resolve({ packId, packName: packId, agentId, displayName: agentId, affectedTargets: [], willRemoveTargets: 0, willPreserveTargets: 0 }),
   removePackFromAgent: (packId: string, agentId: string) =>
@@ -1077,6 +1107,7 @@ function demoOverview(): SkillManagerOverview {
       linkFailPolicy: 'ask',
       startupScan: true,
       showUnmanaged: true,
+      autoSyncSkillPacks: true,
     },
   }
 }


### PR DESCRIPTION
## Summary

- Add a skill pack auto-sync setting, enabled by default.
- Track skill pack revisions and per-Agent sync state in SQLite.
- Auto-sync applied Agents after pack member updates when enabled, or mark them pending when disabled.
- Add manual pack/Agent sync actions and sync state display on the skill pack page.
- Cover new UI text in all five locale files.

## Root Cause

Skill pack updates only changed the pack metadata and member list. Existing Agent installs kept their old pack claims and target contents, so users could not tell which Agents were stale or retry failed syncs.

## Validation

- `pnpm lint`
- `pnpm test:run`
- `pnpm build`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml updating_applied_pack -- --nocapture`

Closes #46
