### PR TITLE
[codex] clarify marketplace skill install flow

### DIFF
--- a/src/components/skills-v2/InstallView.tsx
+++ b/src/components/skills-v2/InstallView.tsx
@@ -429,7 +429,11 @@ export function MarketPanel({ onInstall, onDone }: { onInstall: (source?: string
     return packMembershipBySkillId[marketSkillId(it)] || []
   }, [packMembershipBySkillId])
 
-  const install = async (it: MarketplaceSkill, packChoice: MarketInstallPackChoice = { mode: 'center' }) => {
+  const install = async (
+    it: MarketplaceSkill,
+    packChoice: MarketInstallPackChoice = { mode: 'center' },
+    distributeAfterInstall = true,
+  ) => {
     if (installing.has(it.id)) return
     setInstalling((prev) => new Set(prev).add(it.id))
     setError(null)
@@ -483,7 +487,8 @@ export function MarketPanel({ onInstall, onDone }: { onInstall: (source?: string
         )
       }
       await useSkillStoreV2.getState().loadOverview(true)
-      await onDone(installedSkillId)
+      if (distributeAfterInstall) await onDone(installedSkillId)
+      else await onDone()
     } catch (e) {
       const msg = String(e)
       if (/Blocked skill|requires an explicit decision|冲突/.test(msg)) {
@@ -505,6 +510,25 @@ export function MarketPanel({ onInstall, onDone }: { onInstall: (source?: string
     setError(null)
     setStatus(null)
     setPackDialogSkill(it)
+  }
+
+  const marketActionTitle = (done: boolean) => {
+    if (done) return sourceFilter ? t('skills.marketInstall.addToPackTitle') : t('skills.marketInstall.distributeTitle')
+    return sourceFilter ? t('skills.marketInstall.installOptionsTitle') : t('skills.marketInstall.installTitle')
+  }
+
+  const marketActionLabel = (installing: boolean, done: boolean) => {
+    if (installing) return '…'
+    if (done) return sourceFilter ? '✓' : t('skills.marketInstall.distributeShort')
+    return '+'
+  }
+
+  const installFromCurrentMarketScope = (it: MarketplaceSkill) => {
+    if (sourceFilter) {
+      openInstallDialog(it)
+      return
+    }
+    void install(it)
   }
 
   return (
@@ -696,12 +720,12 @@ export function MarketPanel({ onInstall, onDone }: { onInstall: (source?: string
                       {isCurrentInstalling && <div className="sm2__install-progress"><div className="sm2__install-progress-bar" /></div>}
                     </div>
                     <button
-                      className={`sm2__icon-btn sm2__icon-btn--add${done ? ' sm2__icon-btn--installed' : ''}`}
-                      title={done ? t('skills.marketInstall.addToPackTitle') : t('skills.marketInstall.installOptionsTitle')}
+                      className={`sm2__icon-btn sm2__icon-btn--add${done ? ' sm2__icon-btn--installed' : ''}${done && !sourceFilter ? ' sm2__icon-btn--distribute' : ''}`}
+                      title={marketActionTitle(done)}
                       disabled={isCurrentInstalling}
-                      onClick={(e) => { e.stopPropagation(); openInstallDialog(it) }}
+                      onClick={(e) => { e.stopPropagation(); installFromCurrentMarketScope(it) }}
                     >
-                      {isCurrentInstalling ? '…' : done ? '✓' : '+'}
+                      {marketActionLabel(isCurrentInstalling, done)}
                     </button>
                   </div>
                 )
@@ -722,12 +746,12 @@ export function MarketPanel({ onInstall, onDone }: { onInstall: (source?: string
                         <button className="sm2__icon-btn sm2__icon-btn--sm" title="在市场查看" onClick={(e) => { e.stopPropagation(); openExternal(it.webUrl!) }}>↗</button>
                       )}
                       <button
-                        className={`sm2__icon-btn sm2__icon-btn--add${done ? ' sm2__icon-btn--installed' : ''}`}
-                        title={done ? t('skills.marketInstall.addToPackTitle') : t('skills.marketInstall.installOptionsTitle')}
+                        className={`sm2__icon-btn sm2__icon-btn--add${done ? ' sm2__icon-btn--installed' : ''}${done && !sourceFilter ? ' sm2__icon-btn--distribute' : ''}`}
+                        title={marketActionTitle(done)}
                         disabled={isCurrentInstalling}
-                        onClick={(e) => { e.stopPropagation(); openInstallDialog(it) }}
+                        onClick={(e) => { e.stopPropagation(); installFromCurrentMarketScope(it) }}
                       >
-                        {isCurrentInstalling ? '…' : done ? '✓' : '+'}
+                        {marketActionLabel(isCurrentInstalling, done)}
                       </button>
                     </div>
                     <div className="sm2__install-card-meta">
@@ -793,7 +817,7 @@ export function MarketPanel({ onInstall, onDone }: { onInstall: (source?: string
         installing={detailSkill ? installing.has(detailSkill.id) : false}
         installed={detailSkill ? installedIds.has(detailSkill.id) || isMarketItemInstalled(detailSkill, centerSkills) : false}
         packNames={detailSkill ? packNamesForSkill(detailSkill) : []}
-        onInstall={(it) => { setDetailSkill(null); openInstallDialog(it) }}
+        onInstall={(it) => { setDetailSkill(null); installFromCurrentMarketScope(it) }}
       />
       {packDialogSkill && (
         <MarketInstallPackDialog
@@ -807,7 +831,7 @@ export function MarketPanel({ onInstall, onDone }: { onInstall: (source?: string
           onConfirm={(choice) => {
             const skill = packDialogSkill
             setPackDialogSkill(null)
-            void install(skill, choice)
+            void install(skill, choice, false)
           }}
         />
       )}

--- a/src/components/skills-v2/SkillManagerV2.css
+++ b/src/components/skills-v2/SkillManagerV2.css
@@ -8051,6 +8051,21 @@
   background: #5847f2;
 }
 
+.sm2__install-page .sm2__icon-btn--distribute {
+  width: 58px;
+  padding: 0 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 850;
+  letter-spacing: 0;
+  white-space: nowrap;
+}
+
+.sm2__install-page .sm2__icon-btn--distribute:hover:not(:disabled) {
+  background: #4f46e5;
+  box-shadow: 0 12px 24px rgba(79, 70, 229, 0.28);
+}
+
 .sm2__install-page .sm2__market-list {
   overflow: hidden;
   border: 1px solid var(--sm2-install-border);
@@ -9489,6 +9504,33 @@
 
 .sm2__modal.sm2__modal--market-pack-install {
   width: min(620px, calc(100vw - 28px));
+  overflow: hidden;
+  background: linear-gradient(180deg, #fff7e8 0%, #fffaf1 42%, #fff 100%);
+  border: 1px solid rgba(185, 129, 56, 0.22);
+  box-shadow: 0 24px 70px rgba(23, 28, 43, 0.28);
+}
+
+.sm2__modal--market-pack-install .sm2__modal-head {
+  padding: 20px 22px 16px;
+  border-bottom: 1px solid rgba(185, 129, 56, 0.22);
+  background: rgba(255, 248, 236, 0.72);
+}
+
+.sm2__modal--market-pack-install .sm2__modal-head h3 {
+  margin: 0;
+  color: #171b26;
+  font-size: 18px;
+  line-height: 1.25;
+}
+
+.sm2__modal--market-pack-install .sm2__modal-body {
+  padding: 18px 22px 20px;
+}
+
+.sm2__modal--market-pack-install .sm2__modal-actions {
+  padding: 14px 22px 18px;
+  border-top: 1px solid rgba(185, 129, 56, 0.18);
+  background: rgba(255, 255, 255, 0.78);
 }
 
 .sm2__market-pack-install {
@@ -9501,10 +9543,11 @@
   display: flex;
   align-items: flex-start;
   gap: 12px;
-  padding: 12px;
+  padding: 14px;
   border: 1px solid rgba(40, 51, 77, 0.10);
-  border-radius: 10px;
-  background: rgba(255, 255, 255, 0.72);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 8px 24px rgba(23, 28, 43, 0.05);
 }
 
 .sm2__market-pack-summary > div {
@@ -9536,24 +9579,32 @@
 .sm2__market-pack-options {
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 12px;
 }
 
 .sm2__market-pack-option {
-  display: flex;
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr);
   align-items: flex-start;
-  gap: 10px;
+  gap: 12px;
   min-width: 0;
-  padding: 12px;
-  border: 1px solid rgba(40, 51, 77, 0.11);
-  border-radius: 10px;
-  background: rgba(255, 255, 255, 0.62);
+  padding: 14px;
+  border: 1px solid rgba(40, 51, 77, 0.12);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.86);
   cursor: pointer;
+  transition: border-color 0.16s ease, box-shadow 0.16s ease, background 0.16s ease;
+}
+
+.sm2__market-pack-option:hover {
+  border-color: rgba(108, 92, 255, 0.32);
+  box-shadow: 0 10px 26px rgba(23, 28, 43, 0.06);
 }
 
 .sm2__market-pack-option--active {
-  border-color: rgba(108, 92, 255, 0.45);
-  background: rgba(108, 92, 255, 0.08);
+  border-color: rgba(108, 92, 255, 0.58);
+  background: linear-gradient(180deg, rgba(108, 92, 255, 0.10), rgba(255, 255, 255, 0.90));
+  box-shadow: 0 0 0 1px rgba(108, 92, 255, 0.10), 0 10px 28px rgba(108, 92, 255, 0.08);
 }
 
 .sm2__market-pack-option--disabled {
@@ -9562,10 +9613,9 @@
 }
 
 .sm2__market-pack-option input {
-  width: 16px;
-  height: 16px;
-  flex: 0 0 16px;
-  margin-top: 2px;
+  width: 18px;
+  height: 18px;
+  margin: 1px 0 0;
   accent-color: #6c5cff;
 }
 
@@ -9591,20 +9641,61 @@
 .sm2__market-pack-form {
   display: grid;
   gap: 10px;
-  padding: 0 0 2px 28px;
+  padding: 0 2px 2px 30px;
 }
 
+.sm2__market-pack-picker {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.sm2__market-pack-picker .sm2__search,
 .sm2__market-pack-picker select,
 .sm2__market-pack-form input,
 .sm2__market-pack-form textarea {
   width: 100%;
   min-width: 0;
-  border: 1px solid rgba(40, 51, 77, 0.14);
-  border-radius: 8px;
-  padding: 9px 10px;
-  background: rgba(255, 255, 255, 0.86);
+  border: 1px solid rgba(40, 51, 77, 0.16);
+  border-radius: 10px;
+  background-color: rgba(255, 255, 255, 0.94);
   color: var(--text-primary, #1b1f2a);
   font: inherit;
+  font-size: 13px;
+  outline: none;
+  transition: border-color 0.16s ease, box-shadow 0.16s ease, background-color 0.16s ease;
+}
+
+.sm2__market-pack-picker .sm2__search,
+.sm2__market-pack-picker select,
+.sm2__market-pack-form input {
+  height: 40px;
+  padding: 0 12px;
+}
+
+.sm2__market-pack-picker select {
+  appearance: none;
+  padding-right: 34px;
+  background-image:
+    linear-gradient(45deg, transparent 50%, #687181 50%),
+    linear-gradient(135deg, #687181 50%, transparent 50%);
+  background-position:
+    calc(100% - 18px) 17px,
+    calc(100% - 12px) 17px;
+  background-size: 6px 6px, 6px 6px;
+  background-repeat: no-repeat;
+}
+
+.sm2__market-pack-form textarea {
+  padding: 10px 12px;
+  line-height: 1.45;
+}
+
+.sm2__market-pack-picker .sm2__search:focus-visible,
+.sm2__market-pack-picker select:focus-visible,
+.sm2__market-pack-form input:focus-visible,
+.sm2__market-pack-form textarea:focus-visible {
+  border-color: rgba(108, 92, 255, 0.56);
+  background-color: #fff;
+  box-shadow: 0 0 0 3px rgba(108, 92, 255, 0.12);
 }
 
 .sm2__market-pack-form label {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -724,6 +724,9 @@
       "processing": "Processing..."
     },
     "marketInstall": {
+      "installTitle": "Install",
+      "distributeTitle": "Distribute to Agent",
+      "distributeShort": "Distribute",
       "installOptionsTitle": "Install options",
       "addToPackTitle": "Add to skill pack",
       "dialogTitle": "Install \"{{name}}\"",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -725,6 +725,9 @@
       "processing": "処理中..."
     },
     "marketInstall": {
+      "installTitle": "インストール",
+      "distributeTitle": "Agent に配布",
+      "distributeShort": "配布",
       "installOptionsTitle": "インストール設定",
       "addToPackTitle": "Skill パックに追加",
       "dialogTitle": "「{{name}}」をインストール",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -725,6 +725,9 @@
       "processing": "처리 중..."
     },
     "marketInstall": {
+      "installTitle": "설치",
+      "distributeTitle": "Agent에 배포",
+      "distributeShort": "배포",
       "installOptionsTitle": "설치 옵션",
       "addToPackTitle": "Skill 팩에 추가",
       "dialogTitle": "\"{{name}}\" 설치",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -572,6 +572,9 @@
       "processing": "İşleniyor..."
     },
     "marketInstall": {
+      "installTitle": "Kur",
+      "distributeTitle": "Agent'a dağıt",
+      "distributeShort": "Dağıt",
       "installOptionsTitle": "Kurulum seçenekleri",
       "addToPackTitle": "Skill paketine ekle",
       "dialogTitle": "\"{{name}}\" kur",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -765,6 +765,9 @@
       "processing": "处理中…"
     },
     "marketInstall": {
+      "installTitle": "安装",
+      "distributeTitle": "分发到 Agent",
+      "distributeShort": "分发",
       "installOptionsTitle": "安装选项",
       "addToPackTitle": "加入技能包",
       "dialogTitle": "安装「{{name}}」",

--- a/src/test/skillManagerV2View.test.tsx
+++ b/src/test/skillManagerV2View.test.tsx
@@ -441,6 +441,142 @@ describe('market install state', () => {
   })
 })
 
+describe('Marketplace install flow', () => {
+  beforeEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+    useSkillStoreV2.setState({
+      skills: [],
+      packs: [
+        {
+          id: 'anthropics-skills',
+          name: 'anthropics/skills',
+          description: 'Anthropic skills',
+          tags: ['anthropics/skills'],
+          memberCount: 8,
+          appliedAgentCount: 0,
+          healthy: true,
+        },
+      ],
+      agents: [],
+      overview: null,
+      settings: null,
+      lastOverviewLoadedAt: Date.now(),
+      loadOverview: vi.fn().mockResolvedValue(undefined),
+      loadProjects: vi.fn().mockResolvedValue(undefined),
+    } as Partial<ReturnType<typeof useSkillStoreV2.getState>>)
+  })
+
+  function marketSkill(overrides: Partial<Awaited<ReturnType<typeof skillApiV2.searchMarketplaceSkills>>[number]> = {}) {
+    return {
+      id: 'skillssh:anthropics@skills@brand-guidelines',
+      registryId: 'skills-sh',
+      name: 'brand-guidelines',
+      description: 'Brand skill',
+      source: 'anthropics/skills',
+      installCount: 100,
+      downloadUrl: 'skillssh:anthropics/skills/brand-guidelines',
+      webUrl: 'https://skills.sh/anthropics/skills/brand-guidelines',
+      isInstalled: false,
+      syncedAt: '2026-01-01T00:00:00Z',
+      cacheUpdatedAt: null,
+      ...overrides,
+    }
+  }
+
+  it('installs an outer marketplace card directly without opening the pack dialog', async () => {
+    vi.spyOn(skillApiV2, 'searchMarketplaceSkills').mockResolvedValue([marketSkill()])
+    const executeAdd = vi.spyOn(skillApiV2, 'executeAddCenterSkill').mockResolvedValue({
+      skillIds: ['brand-guidelines'],
+      updated: [],
+      skipped: [],
+    })
+    const onDone = vi.fn()
+
+    const { MarketPanel } = await import('../components/skills-v2/InstallView')
+    render(<MarketPanel onInstall={() => {}} onDone={onDone} />)
+
+    const addButton = await screen.findByTitle('安装')
+    fireEvent.click(addButton)
+
+    await waitFor(() => expect(executeAdd).toHaveBeenCalled())
+    expect(screen.queryByText('安装「brand-guidelines」')).not.toBeInTheDocument()
+    expect(onDone).toHaveBeenCalledWith('brand-guidelines')
+  })
+
+  it('labels an installed outer marketplace card action as distribution', async () => {
+    useSkillStoreV2.setState({
+      skills: [
+        makeSkill({
+          id: 'brand-guidelines',
+          name: 'brand-guidelines',
+          sourceType: 'skillssh',
+          sourceUri: 'skillssh:anthropics/skills/brand-guidelines',
+          installedAgents: [],
+        }),
+      ],
+    })
+    vi.spyOn(skillApiV2, 'searchMarketplaceSkills').mockResolvedValue([marketSkill()])
+
+    const { MarketPanel } = await import('../components/skills-v2/InstallView')
+    render(<MarketPanel onInstall={() => {}} onDone={() => {}} />)
+
+    const distributeButton = await screen.findByTitle('分发到 Agent')
+    expect(distributeButton).toHaveTextContent('分发')
+  })
+
+  it('opens the pack dialog only after entering a source market and completes without distribution handoff', async () => {
+    vi.spyOn(skillApiV2, 'searchMarketplaceSkills').mockResolvedValue([marketSkill()])
+    vi.spyOn(skillApiV2, 'executeAddCenterSkill').mockResolvedValue({
+      skillIds: ['brand-guidelines'],
+      updated: [],
+      skipped: [],
+    })
+    vi.spyOn(skillApiV2, 'getPackDetail').mockResolvedValue({
+      id: 'anthropics-skills',
+      name: 'anthropics/skills',
+      description: 'Anthropic skills',
+      tags: ['anthropics/skills'],
+      appliedAgents: [],
+      members: [],
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    })
+    vi.spyOn(skillApiV2, 'upsertPack').mockResolvedValue({
+      id: 'anthropics-skills',
+      name: 'anthropics/skills',
+      description: 'Anthropic skills',
+      tags: ['anthropics/skills'],
+      members: [
+        {
+          skillId: 'brand-guidelines',
+          skillName: 'brand-guidelines',
+          required: true,
+          sortOrder: 0,
+          missing: false,
+        },
+      ],
+      appliedAgents: [],
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    })
+    const onDone = vi.fn()
+
+    const { MarketPanel } = await import('../components/skills-v2/InstallView')
+    render(<MarketPanel onInstall={() => {}} onDone={onDone} />)
+
+    fireEvent.click(await screen.findByTitle('查看这个创建者的所有市场'))
+    fireEvent.click(await screen.findByText('anthropics/skills'))
+    fireEvent.click(await screen.findByTitle('安装选项'))
+
+    expect(await screen.findByText('安装「brand-guidelines」')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: '安装' }))
+
+    await waitFor(() => expect(onDone).toHaveBeenCalledWith())
+    expect(onDone).not.toHaveBeenCalledWith('brand-guidelines')
+  })
+})
+
 describe('Git install skill preview view modes', () => {
   beforeEach(() => {
     cleanup()


### PR DESCRIPTION
## Summary

- Make top-level marketplace installs skip the skill-pack choice dialog but still hand off to distribution after the center-library install.
- Keep creator/source-scoped installs on the skill-pack choice dialog and suppress the distribution handoff after that dialog completes.
- Change installed top-level marketplace actions from a checkmark-only button to a labeled distribute action, and polish the skill-pack install dialog controls.
- Add regression coverage for the top-level install, source-scoped install, and installed-card distribute label flows.

## Validation

- `pnpm lint`
- `pnpm test:run src/test/skillManagerV2View.test.tsx`
- `pnpm test:run`
- `pnpm build`
- `cargo check --manifest-path src-tauri/Cargo.toml`

`pnpm build` still reports the existing large chunk / ineffective dynamic import warnings, but exits successfully.
