### PR TITLE
chore: 建立 Agent 的 Issue-first 自动交付流程

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -116,8 +116,14 @@ Rust 格式与 lint:`cargo fmt --manifest-path src-tauri/Cargo.toml`、`cargo cl
 
 ## 5. 提交与分支
 
+- **所有会修改仓库文件的任务必须先走 Issue-first 流程。** Bug、需求、重构、测试、文档和配置修改都包含在内；纯问答、只读分析和 code review 不需要，除非后续转为实际修改。
+- 写文件前先搜索是否有同范围 Issue；没有就创建包含背景、目标、验收标准和约束的 Issue。Issue 编号确定之前不得开始修改。
+- 从最新 `origin/dev` 创建独立分支，命名为 `claude/issue-<编号>-<slug>`。如果当前分支属于其他任务，保留现场并使用独立 git worktree。
 - **PR 提到 `dev` 分支**,不是 `main`。`dev` 是集成分支,`main` 是 release 分支。
 - 提交信息走 [Conventional Commits](https://www.conventionalcommits.org/):`feat:`、`fix:`、`docs:`、`refactor:`、`test:`、`chore:`。
+- 完成本地检查后提交并推送；PR 正文必须写 `Closes #<Issue 编号>`。
+- 创建 PR 后执行 `gh pr merge --auto --squash --delete-branch`，持续跟进 CI；失败就修复同一分支，禁止绕过检查或合并红色 PR。只有 PR 已合并，或已明确报告外部阻塞，任务才算结束。
+- 不要为了增加活跃度创建重复、空白或与改动无关的 Issue；每个 Issue 和 PR 都必须对应真实、可审查的工作。
 - 不要在 PR 里 bump 版本号。版本号统一由 maintainer 在出 release 时更新,**且要四处同步**:
   - `package.json` 的 `version`
   - `src-tauri/tauri.conf.json` 的 `version`

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 ## 背景与动机
 
-<!-- 关联 Issue，或说明为什么需要这个改动。 -->
+Closes #<!-- 必填：填写对应 Issue 编号，例如 Closes #61 -->
 
 ## 实现方案
 
@@ -21,6 +21,7 @@
 ## Checklist
 
 - [ ] PR 目标分支是 `dev`，不是 `main`
+- [ ] PR 已通过 `Closes #<编号>` 关联对应 Issue
 - [ ] `pnpm lint` 已通过
 - [ ] `pnpm test:run` 已通过
 - [ ] `pnpm build` 已通过

--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -1,0 +1,23 @@
+name: PR policy
+
+on:
+  pull_request:
+    branches: [dev]
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  issue-link:
+    name: Issue link
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require a closing Issue reference
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if ! printf '%s\n' "$PR_BODY" | grep -Eiq '(^|[^[:alnum:]_])(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]+#[0-9]+([^0-9]|$)'; then
+            echo "::error::PR body must contain a closing reference such as 'Closes #61'."
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,36 @@ cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
 
 Before any PR, all of these must be green: `pnpm lint`, `pnpm test:run`, `pnpm build`, `cargo check`.
 
+## Mandatory GitHub delivery workflow
+
+Use this workflow for every task that changes repository files, including bug fixes, features, refactors, tests, documentation, and configuration.
+
+Pure questions, explanations, code review, read-only diagnosis, and research do not require an Issue or PR unless they turn into a repository change.
+
+### Before editing
+
+1. Confirm GitHub access with `gh auth status` and inspect the current branch and worktree.
+2. Search open Issues for the same scope. Reuse an existing Issue only when it describes the requested work; otherwise create a focused Issue with context, goal, acceptance criteria, and constraints.
+3. Start from the latest `origin/dev` on a dedicated branch named `<agent>/issue-<number>-<slug>` (for example, `codex/issue-61-agent-github-workflow`). Never implement on `dev`, `main`, or an unrelated task branch.
+4. If another task owns the current branch or worktree, preserve it and use a separate git worktree.
+5. Do not edit files until the Issue exists and its number is known.
+
+### Finishing the task
+
+1. Run the required local checks and fix failures before publishing.
+2. Review the diff for unrelated edits and secrets, then create a Conventional Commit.
+3. Push the task branch and open a PR against `dev`. The PR body must contain `Closes #<issue-number>` so merging closes the Issue.
+4. Enable squash auto-merge with branch deletion:
+
+   ```bash
+   gh pr merge --auto --squash --delete-branch
+   ```
+
+5. Monitor required checks. If a check fails, diagnose it, update the same branch, and leave auto-merge enabled. Never bypass checks, force-push shared branches, or merge a failing PR.
+6. The task is complete only when the PR is merged (or when a concrete external blocker is reported). Report the Issue, PR, checks, and merge result.
+
+Do not create duplicate or empty Issues just to increase activity. The Issue and PR must represent real, reviewable work.
+
 ## Where to make changes
 
 | Goal | Files |

--- a/CONTRIBUTING.en.md
+++ b/CONTRIBUTING.en.md
@@ -110,12 +110,13 @@ One commit, one logical change. PRs that include "while I was here, I cleaned up
 
 ## Pull request flow
 
-1. Fork → branch off `dev` → make your changes → run the four checks above.
-2. Open the PR against `dev`. Title should clearly state what changed (English or Chinese).
-3. Fill in the PR template: changes / motivation / implementation / verification / screenshots / checklist.
-4. CI runs `ci.yml` (lint + test + cargo check/clippy/fmt + cargo test) and `build.yml` (macOS dual-arch build). Both must be green.
-5. Review cadence: first response usually within 48 business hours. If a week passes with no reply, feel free to nudge maintainers in the PR.
-6. Merge is squash; maintainers normalize the commit message to Conventional Commits.
+1. Create or claim an Issue that matches the scope of the change.
+2. Fork → branch off `dev` → make your changes → run the four checks above.
+3. Open the PR against `dev`. Title should clearly state what changed (English or Chinese).
+4. Fill in the PR template and keep `Closes #<issue-number>` in the body; `PR policy / Issue link` validates it.
+5. CI runs `ci.yml` (lint + test + cargo check/clippy/fmt + cargo test) and `build.yml` (macOS dual-arch build). Both must be green.
+6. Review cadence: first response usually within 48 business hours. If a week passes with no reply, feel free to nudge maintainers in the PR.
+7. Merge is squash. Repository members may enable auto-merge in advance; the PR merges and deletes its task branch after every required check passes.
 
 ---
 
@@ -154,6 +155,7 @@ Edit `README.md` / `README.en.md` / `docs/*.md` directly. Don't add standalone R
 We encourage AI-assisted contributions — AgentBro is itself a tool for AI coding agents, so the philosophy is consistent.
 
 - **Use the project-level config.** Claude Code auto-loads [`.claude/CLAUDE.md`](.claude/CLAUDE.md). Codex / Cursor / Aider / Copilot / Gemini CLI etc. read [`AGENTS.md`](AGENTS.md). Have your assistant read these *before* it starts editing — it saves a lot of misguided exploration.
+- **Create an Issue before code changes.** The assistant must create or link an Issue before editing, use a dedicated task branch, and close the loop with `Closes #<number>` in the PR. Pure questions and read-only analysis do not need an Issue.
 - **Disclose AI authorship honestly.** If a PR is mostly AI-generated, add a line like "Co-authored with <Agent name>" to the description. We don't discriminate — we just expect honesty.
 - **AI-generated code still has to pass the checks.** `pnpm lint`, `pnpm test:run`, `cargo check` must be green before you open the PR. PRs where the assistant skipped tests / ignored errors / didn't verify will be sent back.
 - **Don't let the AI touch brand assets, signing config, or the release pipeline.** These have trademark and security implications. See the [restricted areas list](.claude/CLAUDE.md#6-禁区不要动).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,12 +110,13 @@ chore: 升级 vitest 到 4.2
 
 ## PR 流程
 
-1. Fork → 在 `dev` 上拉分支 → 改动 → 跑完上面四条检查。
-2. PR base 选 `dev`,标题写清楚改了什么(中英都可)。
-3. 按 PR 模板填:变更内容 / 背景与动机 / 实现方案 / 验证方式 / 截图 / Checklist。
-4. CI 会跑 `ci.yml`(lint + test + cargo check/clippy/fmt + cargo test)和 `build.yml`(macOS 双架构构建)。两个都得绿。
-5. Review 节奏:工作日基本能在 48 小时内给到第一轮反馈。如果一周没人理,可以在 PR 里 @maintainer 提醒一下。
-6. Merge 用 squash;commit message 由 maintainer 整理为 Conventional Commit 风格。
+1. 先创建或认领一个与改动范围一致的 Issue。
+2. Fork → 在 `dev` 上拉分支 → 改动 → 跑完上面四条检查。
+3. PR base 选 `dev`,标题写清楚改了什么(中英都可)。
+4. 按 PR 模板填写内容，并在正文保留 `Closes #<Issue 编号>`；`PR policy / Issue link` 会校验它。
+5. CI 会跑 `ci.yml`(lint + test + cargo check/clippy/fmt + cargo test)和 `build.yml`(macOS 双架构构建)。两个都得绿。
+6. Review 节奏:工作日基本能在 48 小时内给到第一轮反馈。如果一周没人理,可以在 PR 里 @maintainer 提醒一下。
+7. Merge 用 squash；仓库成员可预先开启 auto-merge，所有必需检查通过后会自动合并并删除任务分支。
 
 ---
 
@@ -154,6 +155,7 @@ chore: 升级 vitest 到 4.2
 我们鼓励用 AI 协作 —— AgentBro 自己就是为 AI Agent 服务的工具,理念一致。
 
 - **善用项目级配置**:Claude Code 用户进仓库就能加载 [`.claude/CLAUDE.md`](.claude/CLAUDE.md);Codex / Cursor / Aider / Copilot / Gemini CLI 等读 [`AGENTS.md`](AGENTS.md)。先让 Agent 读这两份再开始改代码,能省大量瞎猜成本。
+- **代码改动先建 Issue**:Agent 必须在写文件前创建或关联 Issue,使用独立任务分支,并在 PR 中用 `Closes #<编号>` 建立闭环。纯问答和只读分析不需要制造 Issue。
 - **PR 描述请如实标注**:如果整份 PR 主要由 AI 生成,在描述里加一句"Co-authored with <Agent 名>"或类似措辞。我们不歧视 AI,但要求诚实。
 - **AI 生成的代码也得自测**:`pnpm lint`、`pnpm test:run`、`cargo check` 全绿再提。AI 跳过测试 / 没看清错误 / 改完不验证的 PR 会被退回。
 - **不要让 AI 改品牌资产、签名配置、发布流程**。这些有商标和安全含义,需要人工判断。具体见 [禁区列表](.claude/CLAUDE.md#6-禁区不要动)。


### PR DESCRIPTION
## 变更内容

- 为 Codex、Claude Code 和其他读取 `AGENTS.md` 的编码 Agent 增加强制 Issue-first 交付规则
- 新增 `PR policy / Issue link` 检查，要求 PR 使用 closing keyword 关联 Issue
- 更新 PR 模板和中英文贡献文档，说明 CI 通过后的 squash auto-merge 流程

## 背景与动机

Closes #61

让每个真实的代码变更都有可追踪的 Issue、独立任务分支和 PR，并在必需检查通过后自动合并；纯问答和只读任务不会创建无意义 Issue。

## 实现方案

项目级指令负责约束 Agent 的执行顺序；GitHub Actions 在服务端校验 PR 正文的 `Closes #<编号>`；仓库设置与 `dev` 分支保护负责阻止绕过 PR 或红色 CI 合并。

## 验证方式

- [x] `pnpm lint`
- [x] `pnpm test:run`（52 个文件，605 个测试）
- [x] `pnpm build`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `git diff --check`
- [x] 手动验证 Issue closing keyword 正反例

## 截图 / 录屏

N/A（流程与文档改动）

## Checklist

- [x] PR 目标分支是 `dev`，不是 `main`
- [x] PR 已通过 `Closes #61` 关联对应 Issue
- [x] `pnpm lint` 已通过
- [x] `pnpm test:run` 已通过
- [x] `pnpm build` 已通过
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` 已通过
- [x] 未修改版本号

Co-authored with Codex.
