### PR TITLE
fix: PR 合并到 dev 后自动关闭关联 Issue

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -122,7 +122,8 @@ Rust 格式与 lint:`cargo fmt --manifest-path src-tauri/Cargo.toml`、`cargo cl
 - **PR 提到 `dev` 分支**,不是 `main`。`dev` 是集成分支,`main` 是 release 分支。
 - 提交信息走 [Conventional Commits](https://www.conventionalcommits.org/):`feat:`、`fix:`、`docs:`、`refactor:`、`test:`、`chore:`。
 - 完成本地检查后提交并推送；PR 正文必须写 `Closes #<Issue 编号>`。
-- 创建 PR 后执行 `gh pr merge --auto --squash --delete-branch`，持续跟进 CI；失败就修复同一分支，禁止绕过检查或合并红色 PR。只有 PR 已合并，或已明确报告外部阻塞，任务才算结束。
+- 创建 PR 后执行 `gh pr merge --auto --squash --delete-branch`，持续跟进 CI；失败就修复同一分支，禁止绕过检查或合并红色 PR。
+- PR 合并后确认 `Close linked Issues` workflow 已关闭关联 Issue；如果仍为 open，执行 `gh issue close <编号> --reason completed` 兜底。只有 PR 已合并且 Issue 已关闭，或已明确报告外部阻塞，任务才算结束。
 - 不要为了增加活跃度创建重复、空白或与改动无关的 Issue；每个 Issue 和 PR 都必须对应真实、可审查的工作。
 - 不要在 PR 里 bump 版本号。版本号统一由 maintainer 在出 release 时更新,**且要四处同步**:
   - `package.json` 的 `version`

--- a/.github/workflows/close-linked-issues.yml
+++ b/.github/workflows/close-linked-issues.yml
@@ -1,21 +1,22 @@
-name: PR policy
+name: Close linked Issues
 
 on:
   pull_request:
     branches: [dev]
-    types: [opened, edited, synchronize, reopened]
+    types: [closed]
 
 permissions:
   contents: read
-  issues: read
+  issues: write
   pull-requests: read
 
 jobs:
-  issue-link:
-    name: Issue link
+  close-linked-issues:
+    name: Close linked Issues
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - name: Require a closing Issue reference
+      - name: Close Issues referenced by the merged PR
         env:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
@@ -23,14 +24,14 @@ jobs:
         run: |
           references="$(printf '%s\n' "$PR_BODY" | grep -Eio '(^|[^[:alnum:]_])(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]+#[0-9]+' || true)"
           if [[ -z "$references" ]]; then
-            echo "::error::PR body must contain a closing reference such as 'Closes #61'."
-            exit 1
+            exit 0
           fi
 
           while read -r issue_number; do
             issue="$(gh api "repos/$GH_REPO/issues/$issue_number")"
-            if jq -e 'has("pull_request")' <<<"$issue" >/dev/null; then
-              echo "::error::#$issue_number is a pull request, not an Issue."
-              exit 1
+            if jq -e 'has("pull_request") or .state == "closed"' <<<"$issue" >/dev/null; then
+              continue
             fi
+            gh api --method PATCH "repos/$GH_REPO/issues/$issue_number" -f state=closed -f state_reason=completed >/dev/null
+            echo "Closed Issue #$issue_number"
           done < <(printf '%s\n' "$references" | grep -Eo '#[0-9]+' | tr -d '#' | sort -u)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Pure questions, explanations, code review, read-only diagnosis, and research do 
 
 1. Run the required local checks and fix failures before publishing.
 2. Review the diff for unrelated edits and secrets, then create a Conventional Commit.
-3. Push the task branch and open a PR against `dev`. The PR body must contain `Closes #<issue-number>` so merging closes the Issue.
+3. Push the task branch and open a PR against `dev`. The PR body must contain `Closes #<issue-number>` so the repository automation can close the Issue after the PR merges.
 4. Enable squash auto-merge with branch deletion:
 
    ```bash
@@ -50,7 +50,8 @@ Pure questions, explanations, code review, read-only diagnosis, and research do 
    ```
 
 5. Monitor required checks. If a check fails, diagnose it, update the same branch, and leave auto-merge enabled. Never bypass checks, force-push shared branches, or merge a failing PR.
-6. The task is complete only when the PR is merged (or when a concrete external blocker is reported). Report the Issue, PR, checks, and merge result.
+6. After the PR merges, verify that the linked Issue was closed by the `Close linked Issues` workflow. If it remains open, close it with `gh issue close <number> --reason completed` and report the fallback.
+7. The task is complete only when the PR is merged and its Issue is closed (or when a concrete external blocker is reported). Report the Issue, PR, checks, and merge result.
 
 Do not create duplicate or empty Issues just to increase activity. The Issue and PR must represent real, reviewable work.
 

--- a/CONTRIBUTING.en.md
+++ b/CONTRIBUTING.en.md
@@ -116,7 +116,7 @@ One commit, one logical change. PRs that include "while I was here, I cleaned up
 4. Fill in the PR template and keep `Closes #<issue-number>` in the body; `PR policy / Issue link` validates it.
 5. CI runs `ci.yml` (lint + test + cargo check/clippy/fmt + cargo test) and `build.yml` (macOS dual-arch build). Both must be green.
 6. Review cadence: first response usually within 48 business hours. If a week passes with no reply, feel free to nudge maintainers in the PR.
-7. Merge is squash. Repository members may enable auto-merge in advance; the PR merges and deletes its task branch after every required check passes.
+7. Merge is squash. Repository members may enable auto-merge in advance; the PR merges and deletes its task branch after every required check passes. `Close linked Issues` closes Issues referenced in the body after the PR merges into `dev`.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,7 +116,7 @@ chore: 升级 vitest 到 4.2
 4. 按 PR 模板填写内容，并在正文保留 `Closes #<Issue 编号>`；`PR policy / Issue link` 会校验它。
 5. CI 会跑 `ci.yml`(lint + test + cargo check/clippy/fmt + cargo test)和 `build.yml`(macOS 双架构构建)。两个都得绿。
 6. Review 节奏:工作日基本能在 48 小时内给到第一轮反馈。如果一周没人理,可以在 PR 里 @maintainer 提醒一下。
-7. Merge 用 squash；仓库成员可预先开启 auto-merge，所有必需检查通过后会自动合并并删除任务分支。
+7. Merge 用 squash；仓库成员可预先开启 auto-merge，所有必需检查通过后会自动合并并删除任务分支。`Close linked Issues` 会在 PR 合并进 `dev` 后关闭正文中关联的 Issue。
 
 ---
 


### PR DESCRIPTION
## 变更内容

- 新增 `Close linked Issues` workflow，在 PR 合并到 `dev` 后关闭正文关联的同仓库 Issue
- 加强 `PR policy / Issue link`，合并前确认 closing reference 指向真实 Issue 而不是 PR
- 更新 Codex、Claude Code 与中英文贡献说明，要求合并后验证 Issue 已关闭并提供 CLI 兜底

## 背景与动机

Closes #63

GitHub 的 closing keyword 只在 PR 合并到默认分支时自动关闭 Issue。AgentBro 的开发 PR 统一合并到非默认分支 `dev`，因此 #62 合并后 #61 仍保持 open。

## 实现方案

在 `pull_request.closed` 事件中检查 `merged == true`，使用最小的 `issues: write` 权限解析 `Closes` / `Fixes` / `Resolves #<编号>`，跳过 PR 编号与已关闭 Issue。合并前的 policy job 使用只读权限验证编号存在且类型正确。

## 验证方式

- [x] `pnpm lint`
- [x] `pnpm test:run`（52 个文件，605 个测试）
- [x] `pnpm build`
- [x] `cargo check --manifest-path src-tauri/Cargo.toml`
- [x] `git diff --check`
- [x] Ruby 解析两个 workflow YAML
- [x] 手动验证真实 Issue `#63` 与 PR 编号 `#62` 的正反例

## 截图 / 录屏

N/A（GitHub workflow 与文档改动）

## Checklist

- [x] PR 目标分支是 `dev`，不是 `main`
- [x] PR 已通过 `Closes #63` 关联对应 Issue
- [x] `pnpm lint` 已通过
- [x] `pnpm test:run` 已通过
- [x] `pnpm build` 已通过
- [x] `cargo check --manifest-path src-tauri/Cargo.toml` 已通过
- [x] 未修改版本号

Co-authored with Codex.
