### PR TITLE
fix: sync skill pack picker runtime target

### DIFF
--- a/src/components/tray/SkillPackPicker.tsx
+++ b/src/components/tray/SkillPackPicker.tsx
@@ -115,6 +115,12 @@ export function SkillPackPicker() {
     }
   }, [])
 
+  const synchronizeAndLoadPickerData = useCallback(async (foreground: boolean) => {
+    await useRuntimeEnvironmentStore.persist.rehydrate()
+    if (isTauri()) await refreshEnvironments()
+    await loadPickerData(foreground)
+  }, [loadPickerData, refreshEnvironments])
+
   useEffect(() => {
     document.documentElement.classList.add('skill-pack-picker-body')
     document.body.classList.add('skill-pack-picker-body')
@@ -125,19 +131,18 @@ export function SkillPackPicker() {
   }, [])
 
   useEffect(() => {
-    void loadPickerData(true)
-  }, [loadPickerData])
-
-  useEffect(() => {
-    if (isTauri()) void refreshEnvironments()
-  }, [refreshEnvironments])
+    void synchronizeAndLoadPickerData(true)
+  }, [synchronizeAndLoadPickerData])
 
   useEffect(() => {
     if (!isTauri()) return
     let cancelled = false
     let unlisten: (() => void) | undefined
     void import('@tauri-apps/api/event')
-      .then(({ listen }) => listen('skill-pack-picker-shown', () => void loadPickerData(false)))
+      .then(({ listen }) => listen(
+        'skill-pack-picker-shown',
+        () => void synchronizeAndLoadPickerData(false),
+      ))
       .then((stopListening) => {
         if (cancelled) stopListening()
         else unlisten = stopListening
@@ -146,7 +151,7 @@ export function SkillPackPicker() {
       cancelled = true
       unlisten?.()
     }
-  }, [loadPickerData])
+  }, [synchronizeAndLoadPickerData])
 
   useEffect(() => {
     const closeOnEscape = (event: KeyboardEvent) => {

--- a/src/test/skillPackPicker.test.tsx
+++ b/src/test/skillPackPicker.test.tsx
@@ -140,6 +140,23 @@ describe('SkillPackPicker', () => {
     expect(await screen.findByRole('checkbox', { name: /前端开发/ })).toBeInTheDocument()
   })
 
+  it('rehydrates the local target before loading a previously remote picker', async () => {
+    useRuntimeEnvironmentStore.setState({ selectedEnvironmentId: 'ubuntu' })
+    window.localStorage.setItem('agentbro-runtime-environment', JSON.stringify({
+      state: { selectedEnvironmentId: LOCAL_RUNTIME_ENVIRONMENT_ID },
+      version: 0,
+    }))
+
+    render(<SkillPackPicker />)
+
+    expect(await screen.findByRole('checkbox', { name: /前端开发/ })).toBeInTheDocument()
+    expect(useRuntimeEnvironmentStore.getState().selectedEnvironmentId).toBe(
+      LOCAL_RUNTIME_ENVIRONMENT_ID,
+    )
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    expect(skillApiV2.getSkillPackPickerData).toHaveBeenCalledTimes(1)
+  })
+
   it('places applied packs before unchecked packs', async () => {
     vi.mocked(skillApiV2.getSkillPackPickerData).mockResolvedValueOnce({
       ...pickerData,


### PR DESCRIPTION
## Summary

- rehydrate the shared runtime-environment selection before loading the skill-pack picker
- refresh available hosts before routing picker data requests
- repeat that synchronization whenever the persistent tray picker is shown
- add a regression test for a picker with stale remote memory after the client switches to local

## Verification

- `pnpm lint`
- `pnpm test:run` (53 files, 617 tests)
- `pnpm build`
- `cargo check --manifest-path src-tauri/Cargo.toml`

Closes #72