### PR TITLE
fix: show ZCode inherited shared skills

### DIFF
--- a/docs/plans/2026-07-29-zcode-inherited-shared-skills-design.md
+++ b/docs/plans/2026-07-29-zcode-inherited-shared-skills-design.md
@@ -98,4 +98,3 @@ Frontend tests cover:
 - Inherited cards expose no mutating actions.
 - Search, card/list mode, empty state, and tab switching remain functional.
 - Existing managed, unmanaged, and built-in behavior remains unchanged.
-

--- a/docs/plans/2026-07-29-zcode-inherited-shared-skills-design.md
+++ b/docs/plans/2026-07-29-zcode-inherited-shared-skills-design.md
@@ -1,0 +1,101 @@
+# ZCode Inherited Shared Skills
+
+Issue: <https://github.com/shirenchuang/agentbro/issues/76>
+
+## Context
+
+ZCode loads user skills from its private `~/.zcode/skills` directory and from
+the shared `~/.agents/skills` directory. AgentBro currently shows only
+ZCode-private targets in the ZCode Agent Management view. On a machine where
+ZCode successfully lists dozens of shared skills, AgentBro can therefore report
+`Skills (0)`.
+
+AgentBro already inventories `~/.agents/skills` as a shared source. Those items
+must remain owned by the shared inventory: showing them in ZCode must not turn
+them into ZCode-private targets or expose duplicate adoption, deletion, or skill
+pack actions.
+
+## User Experience
+
+The existing `Agent 管理 → ZCode → Skills` view gains a fourth scope beside
+`已管理`, `未管理`, and `内置`:
+
+`共享继承 <count>`
+
+The Skills tab total and the ZCode summary strip include inherited skills. The
+scope opens as a read-only collection using the existing card/list view switch
+and search field.
+
+The top of the inherited scope displays:
+
+> ZCode 默认读取 `~/.agents/skills`。这里展示该共享目录中当前可用的 Skill；
+> 它们可能同时被 Codex、Kimi 等 Agent 使用。此处仅展示继承关系，不会将其视为
+> ZCode 私有安装项。
+
+Each item is labeled `.agents 共享目录` and shows its logical shared path. A
+symlinked skill may also expose its resolved source path in the detail view.
+There are no select, adopt, delete, move-to-pack, or distribution controls in
+this scope.
+
+Plugin-provided skills remain represented by the existing Plugins surface and
+are not mixed into `共享继承`.
+
+## Data Flow
+
+The backend continues scanning `~/.agents/skills` once as the dedicated shared
+inventory. ZCode Agent detail derives a read-only inherited-skills projection
+from those existing shared inventory rows.
+
+The projection contains only display data:
+
+- stable item ID
+- skill name
+- logical path under `~/.agents/skills`
+- resolved source path when the logical path is a symlink
+
+It does not create `skill_targets`, claims, pack membership, or a second
+unmanaged record for ZCode.
+
+The frontend renders the projection in its own `inherited` scope. It never
+passes inherited items to existing mutation handlers.
+
+## Semantics
+
+| Scope | Meaning | Mutating actions |
+| --- | --- | --- |
+| 已管理 | AgentBro distributed the skill to `~/.zcode/skills` | Existing controls |
+| 未管理 | A private ZCode skill exists outside AgentBro management | Adopt/delete |
+| 共享继承 | ZCode can read the shared `~/.agents/skills` item | None |
+| 内置 | Agent/runtime-provided read-only skill | None |
+
+This preserves the distinction between availability and ownership. The ZCode
+count reflects effective user skills without pretending AgentBro privately
+installed them.
+
+## Error Handling
+
+- A missing or empty `~/.agents/skills` directory yields an empty inherited
+  scope and no warning.
+- Broken links are excluded by the existing shared inventory scan and remain
+  diagnosable through the shared inventory/diagnosis surfaces.
+- Duplicate skill names follow the shared inventory result; the ZCode view does
+  not introduce a second deduplication or precedence system.
+- Failure to resolve a symlink keeps the logical path available for display.
+
+## Testing
+
+Backend tests cover:
+
+- ZCode Agent detail includes shared inventory items as inherited skills.
+- Inherited items retain the logical `.agents` path and resolved source path.
+- No ZCode target or duplicate unmanaged record is created.
+- Other Agent details do not gain ZCode-only inherited projections.
+
+Frontend tests cover:
+
+- ZCode totals include inherited skills.
+- `共享继承` shows the count, explanation, source label, and path.
+- Inherited cards expose no mutating actions.
+- Search, card/list mode, empty state, and tab switching remain functional.
+- Existing managed, unmanaged, and built-in behavior remains unchanged.
+

--- a/src-tauri/src/skills/v2/models.rs
+++ b/src-tauri/src/skills/v2/models.rs
@@ -275,11 +275,21 @@ pub struct AgentDetail {
     pub plugin_dir: Option<String>,
     pub agent_dir: Option<String>,
     pub skills: Vec<SkillTargetDetail>,
+    pub inherited_skills: Vec<InheritedSkillDetail>,
     pub applied_packs: Vec<AppliedPackSummary>,
     pub available_packs: Vec<SkillPackSummary>,
     pub mcp_servers: Vec<McpServerStatus>,
     pub plugins: Vec<PluginStatus>,
     pub health: Vec<AgentHealthIssue>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InheritedSkillDetail {
+    pub id: String,
+    pub skill_id: String,
+    pub path: String,
+    pub resolved_path: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/skills/v2/service.rs
+++ b/src-tauri/src/skills/v2/service.rs
@@ -5211,6 +5211,12 @@ impl Service {
                 claims,
             });
         }
+        let mut inherited_skills = self.inherited_skills_for_agent(agent_id)?;
+        inherited_skills.sort_by(|left, right| {
+            left.skill_id
+                .to_lowercase()
+                .cmp(&right.skill_id.to_lowercase())
+        });
 
         let applied_packs = self.applied_packs_for_agent(agent_id)?;
         let available_packs = self.list_skill_packs()?;
@@ -5257,12 +5263,65 @@ impl Service {
             plugin_dir,
             agent_dir,
             skills,
+            inherited_skills,
             applied_packs,
             available_packs,
             mcp_servers,
             plugins,
             health,
         })
+    }
+
+    fn inherited_skills_for_agent(
+        &self,
+        agent_id: &str,
+    ) -> Result<Vec<InheritedSkillDetail>, String> {
+        if agent_id != "zcode" {
+            return Ok(Vec::new());
+        }
+        let rows = self.db.with_conn(|connection| {
+            let mut statement = connection
+                .prepare(
+                    "SELECT 'target:' || id, skill_id, target_path
+                     FROM skill_targets
+                     WHERE agent_id = ?1
+                     UNION ALL
+                     SELECT 'unmanaged:' || id, COALESCE(inferred_skill_id, ''), path
+                     FROM unmanaged_items
+                     WHERE agent_id = ?1 AND item_type IN ('skill', 'agent_skill')
+                     ORDER BY 3",
+                )
+                .map_err(|error| error.to_string())?;
+            let rows = statement
+                .query_map([SHARED_SKILLS_AGENT_ID], |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, String>(2)?,
+                    ))
+                })
+                .map_err(|error| error.to_string())?;
+            let mut values = Vec::new();
+            for row in rows {
+                values.push(row.map_err(|error| error.to_string())?);
+            }
+            Ok::<_, String>(values)
+        })?;
+        let mut seen_paths = BTreeSet::new();
+        Ok(rows
+            .into_iter()
+            .filter(|(_, _, path)| seen_paths.insert(path.clone()))
+            .map(|(id, skill_id, path)| InheritedSkillDetail {
+                id,
+                skill_id: if skill_id.trim().is_empty() {
+                    infer_name_from_path(&path)
+                } else {
+                    skill_id
+                },
+                resolved_path: resolved_target_path(&path),
+                path,
+            })
+            .collect())
     }
 
     fn applied_packs_for_agent(&self, agent_id: &str) -> Result<Vec<AppliedPackSummary>, String> {

--- a/src-tauri/src/skills/v2/tests.rs
+++ b/src-tauri/src/skills/v2/tests.rs
@@ -3763,6 +3763,55 @@ fn agent_detail_reads_zcode_nested_mcp_and_plugins() {
 }
 
 #[test]
+#[cfg(unix)]
+fn zcode_agent_detail_projects_shared_skills_as_inherited() {
+    let (_home, svc, _lock) = fresh_service("zcode-inherited-shared-skills");
+    let shared_root = svc.home.join(".agents/skills");
+    let local = write_skill(&shared_root, "shared-local", "shared-local", Some("shared"));
+    let source = write_skill(
+        &svc.home.join("skill-sources"),
+        "linked-source",
+        "shared-linked",
+        Some("linked"),
+    );
+    let linked = shared_root.join("shared-linked");
+    std::os::unix::fs::symlink(&source, &linked).unwrap();
+
+    svc.refresh().unwrap();
+
+    let detail = svc.get_agent_detail("zcode").unwrap();
+    assert!(detail.skills.is_empty());
+    assert_eq!(detail.inherited_skills.len(), 2);
+    assert!(detail.inherited_skills.iter().any(|skill| {
+        skill.skill_id == "shared-local"
+            && skill.path == local.display().to_string()
+            && skill.resolved_path.is_none()
+    }));
+    assert!(detail.inherited_skills.iter().any(|skill| {
+        skill.skill_id == "shared-linked"
+            && skill.path == linked.display().to_string()
+            && skill.resolved_path.as_deref() == Some(source.to_string_lossy().as_ref())
+    }));
+
+    let unmanaged = svc.list_unmanaged().unwrap();
+    assert_eq!(
+        unmanaged
+            .iter()
+            .filter(|item| item.agent_id.as_deref() == Some("agents"))
+            .count(),
+        2
+    );
+    assert!(!unmanaged
+        .iter()
+        .any(|item| item.agent_id.as_deref() == Some("zcode")));
+    assert!(svc
+        .get_agent_detail("claude-code")
+        .unwrap()
+        .inherited_skills
+        .is_empty());
+}
+
+#[test]
 fn agent_detail_reports_codex_toml_config_paths() {
     let (_home, svc, _lock) = fresh_service("codex-config-paths");
     let codex_dir = svc.home.join(".codex");

--- a/src/components/skills-v2/AgentManagementPage.tsx
+++ b/src/components/skills-v2/AgentManagementPage.tsx
@@ -6,7 +6,7 @@ import { useSkillStoreV2 } from '../../stores/skillStoreV2'
 import { skillApiV2 } from '../../services/skillApiV2'
 import { agentApi, type AgentOutputEvent, type AgentProgramInfo, type CustomAgentConfig } from '../../services/agentApi'
 import { configureAgentHookEvents, getAllHookStatus, installAgentHook, uninstallAgentHook, type HookEventStatus, type HookStatus } from '../../services/tauriApi'
-import type { AgentConfigDocument, AgentDetail, AdoptPreview, ConflictBlocker, DistributionBlockerDecision, DistributionPreview, MoveDirectSkillToPackPreview, SkillPackSummary, SkillSummary, UnmanagedItemDto } from '../../services/skillApiV2'
+import type { AgentConfigDocument, AgentDetail, AdoptPreview, ConflictBlocker, DistributionBlockerDecision, DistributionPreview, InheritedSkillDetail, MoveDirectSkillToPackPreview, SkillPackSummary, SkillSummary, UnmanagedItemDto } from '../../services/skillApiV2'
 import { useSessionStore } from '../../stores/sessionStore'
 import {
   LOCAL_RUNTIME_ENVIRONMENT_ID,
@@ -23,7 +23,7 @@ import { buildAgentUsageScores, readStoredAgentOrder, sortAgentSummaries } from 
 
 type DetailTab = 'overview' | 'skills' | 'mcp' | 'plugins' | 'hooks' | 'config'
 type AgentSkillViewMode = 'cards' | 'list'
-type AgentSkillScope = 'managed' | 'unmanaged' | 'builtin'
+type AgentSkillScope = 'managed' | 'unmanaged' | 'inherited' | 'builtin'
 type AgentSkillPackFilter = 'all' | 'pack' | 'standalone'
 type AgentLibraryScope = 'uninstalled' | 'installed' | 'all'
 type InstallBlockerDecision = 'overwrite' | 'skip'
@@ -288,7 +288,7 @@ export function AgentManagementPage() {
     setNotice(null)
     state.setError(null)
     try {
-      const scanIds = agentId === 'codex' ? [agentId, SHARED_SKILLS_AGENT_ID] : [agentId]
+      const scanIds = ['codex', 'zcode'].includes(agentId) ? [agentId, SHARED_SKILLS_AGENT_ID] : [agentId]
       const results = await Promise.all(scanIds.map((id) => skillApiV2.scanAgentInventory(id)))
       const unmanaged = await skillApiV2.listUnmanaged()
       useSkillStoreV2.setState({ unmanaged })
@@ -1027,6 +1027,7 @@ function AgentDetailView({
   const observedSkills = useSkillStoreV2((s) => s.unmanaged).filter((u) => unmanagedVisibleForAgent(detail.id, u))
   const unmanaged = observedSkills.filter((item) => showUnmanaged && !isReadOnlyUnmanaged(item))
   const readOnlySkills = observedSkills.filter(isReadOnlyUnmanaged)
+  const inheritedSkills = detail.inheritedSkills ?? []
   const installed = program ? program.status === 'installed' || program.status === 'updateAvailable' : agentInstalled
   const canInstall = Boolean(program?.installCommand)
   const canOpenDownload = Boolean(program?.downloadUrl)
@@ -1047,7 +1048,7 @@ function AgentDetailView({
     : { label: updating ? '正在更新' : hasUpdate ? '更新此 Agent' : '无需更新', disabled: busy || scanning || updating || !hasUpdate, onClick: () => onUpdate(detail.id), busy: updating }
   const tabs: Array<{ id: DetailTab; label: string }> = [
     { id: 'overview', label: '概览' },
-    { id: 'skills', label: `Skills (${detail.skills.length + unmanaged.length + readOnlySkills.length})` },
+    { id: 'skills', label: `Skills (${detail.skills.length + unmanaged.length + inheritedSkills.length + readOnlySkills.length})` },
     { id: 'mcp', label: `MCP (${detail.mcpServers.length})` },
     { id: 'plugins', label: `Plugins (${detail.plugins.length})` },
     { id: 'hooks', label: 'Hooks' },
@@ -1070,6 +1071,7 @@ function AgentDetailView({
         <div className="sm2__agent-summary-strip" aria-label="Agent 摘要">
           <Stat value={detail.skills.length} label="已管理" />
           {showUnmanaged && <Stat value={unmanaged.length} label="未管理" tone={unmanaged.length > 0 ? 'warn' : 'ok'} />}
+          {detail.id === 'zcode' && <Stat value={inheritedSkills.length} label={t('skills.agentManagement.inheritedSkills')} />}
           {readOnlySkills.length > 0 && <Stat value={readOnlySkills.length} label={t('skills.agentManagement.builtinSkills')} />}
           <Stat value={detail.appliedPacks.length} label="技能包" />
           <Stat value={detail.mcpServers.length + detail.plugins.length} label="MCP/插件" />
@@ -1127,6 +1129,7 @@ function AgentDetailView({
           <SkillsTab
             detail={detail}
             unmanaged={unmanaged}
+            inheritedSkills={inheritedSkills}
             readOnlySkills={readOnlySkills}
             showUnmanaged={showUnmanaged}
             busy={busy}
@@ -1176,6 +1179,7 @@ function OverviewTab({
   const unmanagedCount = observedSkills
     .filter((item) => showUnmanaged && !isReadOnlyUnmanaged(item)).length
   const readOnlyCount = observedSkills.filter(isReadOnlyUnmanaged).length
+  const inheritedCount = detail.inheritedSkills?.length ?? 0
   const appliedIds = new Set(detail.appliedPacks.map((p) => p.packId))
   const available = detail.availablePacks.filter((p) => !appliedIds.has(p.id))
   const validMcpCount = detail.mcpServers.filter((server) => server.valid).length
@@ -1224,11 +1228,13 @@ function OverviewTab({
     {
       id: 'skills',
       label: 'Skills',
-      value: detail.skills.length + readOnlyCount,
+      value: detail.skills.length + inheritedCount + readOnlyCount,
       unit: '可用',
       detail: unmanagedCount > 0
         ? `${unmanagedCount} 个待接管`
-        : readOnlyCount > 0 ? `${readOnlyCount} 个 Agent 内置只读` : '全部已纳入管理',
+        : inheritedCount > 0
+          ? `${inheritedCount} 个来自 .agents 共享继承`
+          : readOnlyCount > 0 ? `${readOnlyCount} 个 Agent 内置只读` : '全部已纳入管理',
       tab: 'skills',
       tone: unmanagedCount > 0 ? 'amber' : 'blue',
       progress: detail.skills.length + unmanagedCount === 0 ? 100 : detail.skills.length / (detail.skills.length + unmanagedCount) * 100,
@@ -1435,6 +1441,7 @@ function OverviewTab({
 function SkillsTab({
   detail,
   unmanaged,
+  inheritedSkills,
   readOnlySkills,
   showUnmanaged,
   busy,
@@ -1448,6 +1455,7 @@ function SkillsTab({
 }: {
   detail: AgentDetail
   unmanaged: UnmanagedItemDto[]
+  inheritedSkills: InheritedSkillDetail[]
   readOnlySkills: UnmanagedItemDto[]
   showUnmanaged: boolean
   busy: boolean
@@ -1514,6 +1522,16 @@ function SkillsTab({
         .includes(q),
     )
   }, [q, t, unmanaged])
+  const filteredInherited = useMemo(() => {
+    if (!q) return inheritedSkills
+    return inheritedSkills.filter((item) =>
+      [item.skillId, item.path, item.resolvedPath]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase()
+        .includes(q),
+    )
+  }, [inheritedSkills, q])
   const filteredReadOnly = useMemo(() => {
     if (!q) return readOnlySkills
     return readOnlySkills.filter((item) =>
@@ -1531,6 +1549,7 @@ function SkillsTab({
     if (page !== 1) setPage(1)
   }
   const shownUnmanaged = filteredUnmanaged.slice(0, page * PAGE_SIZE)
+  const shownInherited = filteredInherited.slice(0, page * PAGE_SIZE)
   const shownReadOnly = filteredReadOnly.slice(0, page * PAGE_SIZE)
   const canManageUnmanaged = filteredUnmanaged
   const quickTakeoverCandidates = useMemo(
@@ -1559,6 +1578,10 @@ function SkillsTab({
     setDeleteUnmanagedTarget(null)
     setDeleteUnmanagedError(null)
   }, [detail.id, packFilter, scope])
+
+  useEffect(() => {
+    if (scope === 'inherited' && detail.id !== 'zcode') setScope('managed')
+  }, [detail.id, scope])
 
   useEffect(() => {
     if (!localNotice) return
@@ -1881,6 +1904,15 @@ function SkillsTab({
             未管理 {filteredUnmanaged.length}
           </button>
         )}
+        {detail.id === 'zcode' && (
+          <button
+            className={scope === 'inherited' ? 'active' : ''}
+            aria-selected={scope === 'inherited'}
+            onClick={() => setScope('inherited')}
+          >
+            {t('skills.agentManagement.inheritedSkills')} {filteredInherited.length}
+          </button>
+        )}
         {readOnlySkills.length > 0 && (
           <button
             className={scope === 'builtin' ? 'active' : ''}
@@ -2094,6 +2126,32 @@ function SkillsTab({
               {shownReadOnly.length < filteredReadOnly.length && (
                 <button className="sm2__btn sm2__btn--ghost sm2__load-more" onClick={() => setPage((p) => p + 1)}>
                   继续显示 {Math.min(PAGE_SIZE, filteredReadOnly.length - shownReadOnly.length)} 个
+                </button>
+              )}
+            </>
+          )}
+        </>
+      )}
+
+      {scope === 'inherited' && detail.id === 'zcode' && (
+        <>
+          <div className="sm2__notice sm2__notice--info">
+            {t('skills.agentManagement.inheritedSkillsNotice')}
+          </div>
+          {filteredInherited.length === 0 ? (
+            <div className="sm2__empty sm2__empty--compact">
+              {t('skills.agentManagement.inheritedSkillsNoResults')}
+            </div>
+          ) : (
+            <>
+              <InheritedSkillCollection
+                skills={shownInherited}
+                mode={viewMode}
+                onOpenSkillDetail={onOpenSkillDetail}
+              />
+              {shownInherited.length < filteredInherited.length && (
+                <button className="sm2__btn sm2__btn--ghost sm2__load-more" onClick={() => setPage((p) => p + 1)}>
+                  继续显示 {Math.min(PAGE_SIZE, filteredInherited.length - shownInherited.length)} 个
                 </button>
               )}
             </>
@@ -3283,6 +3341,71 @@ function ManagedSkillListRow({
   )
 }
 
+function InheritedSkillCollection({
+  skills,
+  mode,
+  onOpenSkillDetail,
+}: {
+  skills: InheritedSkillDetail[]
+  mode: AgentSkillViewMode
+  onOpenSkillDetail: (skillId: string, fallback?: SkillDetailFallback | null) => void
+}) {
+  const { t } = useTranslation()
+  if (mode === 'list') {
+    return (
+      <div className="sm2__agent-skill-list">
+        {skills.map((skill) => (
+          <div
+            key={skill.id}
+            className="sm2__object-row sm2__object-row--path sm2__object-row--clickable"
+            onClick={() => openInheritedSkill(skill, onOpenSkillDetail)}
+          >
+            <div>
+              <strong>{skill.skillId}</strong>
+              <span>{t('skills.agentManagement.inheritedSkillsSource')}</span>
+              <code title={skill.resolvedPath ?? undefined}>{skill.path}</code>
+            </div>
+            <span className="sm2__tag sm2__tag--shared">
+              {t('skills.agentManagement.inheritedSkills')}
+            </span>
+          </div>
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <div className="sm2__agent-skill-grid">
+      {skills.map((skill) => (
+        <article
+          key={skill.id}
+          className="sm2__agent-skill-card sm2__agent-skill-card--clickable"
+          role="button"
+          tabIndex={0}
+          onClick={() => openInheritedSkill(skill, onOpenSkillDetail)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              openInheritedSkill(skill, onOpenSkillDetail)
+            }
+          }}
+        >
+          <div className="sm2__agent-skill-card-head">
+            <div className="sm2__agent-skill-icon">{initials(skill.skillId || 'SK')}</div>
+            <div className="sm2__agent-skill-card-titleline">
+              <strong>{skill.skillId}</strong>
+              <span>{t('skills.agentManagement.inheritedSkillsSource')}</span>
+            </div>
+            <span className="sm2__tag sm2__tag--shared">
+              {t('skills.agentManagement.inheritedSkills')}
+            </span>
+          </div>
+          <code title={skill.resolvedPath ?? undefined}>{skill.path}</code>
+        </article>
+      ))}
+    </div>
+  )
+}
+
 function UnmanagedSkillCollection({
   skills,
   mode,
@@ -3555,6 +3678,19 @@ function openUnmanagedSkill(
     currentHash: item.hash,
     sourceType: 'unmanaged_agent',
     sourceUri: item.path,
+  })
+}
+
+function openInheritedSkill(
+  item: InheritedSkillDetail,
+  onOpenSkillDetail: (skillId: string, fallback?: SkillDetailFallback | null) => void,
+) {
+  onOpenSkillDetail(item.skillId, {
+    id: item.skillId,
+    name: item.skillId,
+    centerPath: item.path,
+    sourceType: 'unmanaged_agent',
+    sourceUri: item.resolvedPath || item.path,
   })
 }
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1222,6 +1222,10 @@
         "complete": "Takeover complete: {{adopted}} managed, {{failed}} failed. Other unmanaged Skills were unchanged.",
         "refreshFailed": "Refresh failed: {{error}}"
       },
+      "inheritedSkills": "Inherited",
+      "inheritedSkillsSource": ".agents shared directory",
+      "inheritedSkillsNotice": "ZCode reads ~/.agents/skills by default. This list shows Skills currently available from that shared directory; Codex, Kimi, and other Agents may use them too. This view only shows inheritance and does not treat them as private ZCode installations.",
+      "inheritedSkillsNoResults": "No Skills inherited from ~/.agents/skills were found.",
       "builtinSkills": "Built-in",
       "builtinSkillsNotice": "{{count}} Skills are provided by {{agent}} and shown read-only. AgentBro will not adopt, overwrite, or delete these files.",
       "builtinSkillsNoResults": "No built-in Skills match this search.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1223,6 +1223,10 @@
         "complete": "一括取り込み完了：{{adopted}} 個を管理、{{failed}} 個が失敗。その他の未管理 Skill は変更していません。",
         "refreshFailed": "更新に失敗しました：{{error}}"
       },
+      "inheritedSkills": "共有継承",
+      "inheritedSkillsSource": ".agents 共有ディレクトリ",
+      "inheritedSkillsNotice": "ZCode はデフォルトで ~/.agents/skills を読み込みます。ここには共有ディレクトリから現在利用できる Skill が表示され、Codex、Kimi などの Agent でも同時に使用される場合があります。この画面は継承関係のみを表示し、ZCode 固有のインストールとしては扱いません。",
+      "inheritedSkillsNoResults": "~/.agents/skills から継承された Skill が見つかりません。",
       "builtinSkills": "組み込み",
       "builtinSkillsNotice": "{{count}} 個の Skill は {{agent}} が提供する組み込み機能で、読み取り専用で表示されます。AgentBro はこれらのファイルを引き継ぎ、上書き、削除しません。",
       "builtinSkillsNoResults": "検索条件に一致する組み込み Skill はありません。",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1223,6 +1223,10 @@
         "complete": "일괄 가져오기 완료: {{adopted}}개 관리됨, {{failed}}개 실패. 다른 관리되지 않는 Skill은 변경하지 않았습니다.",
         "refreshFailed": "새로 고침 실패: {{error}}"
       },
+      "inheritedSkills": "공유 상속",
+      "inheritedSkillsSource": ".agents 공유 디렉터리",
+      "inheritedSkillsNotice": "ZCode는 기본적으로 ~/.agents/skills를 읽습니다. 여기에는 공유 디렉터리에서 현재 사용할 수 있는 Skill이 표시되며 Codex, Kimi 등의 Agent에서도 함께 사용할 수 있습니다. 이 화면은 상속 관계만 표시하며 ZCode 전용 설치로 취급하지 않습니다.",
+      "inheritedSkillsNoResults": "~/.agents/skills에서 상속된 Skill을 찾을 수 없습니다.",
       "builtinSkills": "기본 제공",
       "builtinSkillsNotice": "{{count}}개의 Skill은 {{agent}}에서 기본 제공하며 읽기 전용으로 표시됩니다. AgentBro는 이 파일을 인계, 덮어쓰기 또는 삭제하지 않습니다.",
       "builtinSkillsNoResults": "검색과 일치하는 기본 제공 Skill이 없습니다.",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -1071,6 +1071,10 @@
         "complete": "Devralma tamamlandı: {{adopted}} yönetildi, {{failed}} başarısız. Diğer yönetilmeyen Skill'ler değiştirilmedi.",
         "refreshFailed": "Yenileme başarısız: {{error}}"
       },
+      "inheritedSkills": "Paylaşılan miras",
+      "inheritedSkillsSource": ".agents paylaşılan dizini",
+      "inheritedSkillsNotice": "ZCode varsayılan olarak ~/.agents/skills dizinini okur. Burada paylaşılan dizinden kullanılabilen Skill'ler gösterilir; Codex, Kimi ve diğer Agent'lar da bunları kullanabilir. Bu görünüm yalnızca miras ilişkisini gösterir ve bunları ZCode'a özel kurulumlar olarak değerlendirmez.",
+      "inheritedSkillsNoResults": "~/.agents/skills dizininden miras alınan Skill bulunamadı.",
       "builtinSkills": "Yerleşik",
       "builtinSkillsNotice": "{{count}} Skill, {{agent}} tarafından sağlanır ve salt okunur gösterilir. AgentBro bu dosyaları devralmaz, üzerlerine yazmaz veya silmez.",
       "builtinSkillsNoResults": "Bu aramayla eşleşen yerleşik Skill yok.",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1263,6 +1263,10 @@
         "complete": "一键接管完成：已接管 {{adopted}} 个，失败 {{failed}} 个；其他未管理 Skill 保持不变。",
         "refreshFailed": "刷新失败：{{error}}"
       },
+      "inheritedSkills": "共享继承",
+      "inheritedSkillsSource": ".agents 共享目录",
+      "inheritedSkillsNotice": "ZCode 默认读取 ~/.agents/skills。这里展示该共享目录中当前可用的 Skill；它们可能同时被 Codex、Kimi 等 Agent 使用。此处仅展示继承关系，不会将其视为 ZCode 私有安装项。",
+      "inheritedSkillsNoResults": "没有找到从 ~/.agents/skills 继承的 Skill。",
       "builtinSkills": "内置",
       "builtinSkillsNotice": "{{count}} 个 Skill 由 {{agent}} 内置提供，仅作只读展示。AgentBro 不会接管、覆盖或删除这些文件。",
       "builtinSkillsNoResults": "没有匹配的内置 Skill。",

--- a/src/services/skillApiV2.ts
+++ b/src/services/skillApiV2.ts
@@ -407,6 +407,13 @@ export interface AgentHealthIssue {
   severity: string
 }
 
+export interface InheritedSkillDetail {
+  id: string
+  skillId: string
+  path: string
+  resolvedPath: string | null
+}
+
 export interface AgentDetail {
   id: string
   displayName: string
@@ -419,6 +426,7 @@ export interface AgentDetail {
   pluginDir: string | null
   agentDir?: string | null
   skills: SkillTargetDetail[]
+  inheritedSkills?: InheritedSkillDetail[]
   appliedPacks: AppliedPackSummary[]
   availablePacks: SkillPackSummary[]
   mcpServers: McpServerStatus[]

--- a/src/test/skillManagerV2View.test.tsx
+++ b/src/test/skillManagerV2View.test.tsx
@@ -3324,6 +3324,78 @@ describe('Skill detail slider + agent page render without crashing', () => {
     expect(container.querySelector('.sm2__agent-skill-list')).not.toBeNull()
   })
 
+  it('shows ZCode shared skills in a read-only inherited scope', async () => {
+    const zcodeDetail: AgentDetail = {
+      ...agentDetail,
+      id: 'zcode',
+      displayName: 'ZCode',
+      iconKey: 'zcode',
+      skillsDir: '/Users/me/.zcode/skills',
+      skills: [],
+      inheritedSkills: [
+        {
+          id: 'unmanaged-shared-review',
+          skillId: 'shared-review',
+          path: '/Users/me/.agents/skills/shared-review',
+          resolvedPath: '/Users/me/.agentbro/skills/shared-review',
+        },
+        {
+          id: 'unmanaged-shared-writing',
+          skillId: 'shared-writing',
+          path: '/Users/me/.agents/skills/shared-writing',
+          resolvedPath: null,
+        },
+      ],
+    }
+    useSkillStoreV2.setState({
+      agents: [
+        { id: 'zcode', displayName: 'ZCode', iconKey: 'zcode', enabled: true, skillsDir: '/Users/me/.zcode/skills', version: '3.5.3', latestVersion: null, installed: true, managedSkillCount: 0, unmanagedSkillCount: 0 } as AgentSummary,
+      ],
+      selectedAgentId: 'zcode',
+      selectedAgentDetail: zcodeDetail,
+      unmanaged: [],
+    })
+    const scan = vi.spyOn(skillApiV2, 'scanAgentInventory').mockImplementation(async (agentId) => ({
+      agentId,
+      managed: 0,
+      unmanaged: agentId === 'agents' ? 2 : 0,
+    }))
+    vi.spyOn(skillApiV2, 'listUnmanaged').mockResolvedValue([])
+    vi.spyOn(skillApiV2, 'getAgentDetail').mockResolvedValue(zcodeDetail)
+    vi.spyOn(skillApiV2, 'overview').mockResolvedValue(makeOverview())
+
+    const { AgentManagementPage } = await import('../components/skills-v2/AgentManagementPage')
+    const { container } = render(<AgentManagementPage />)
+
+    expect(screen.getByRole('button', { name: 'Skills (2)' })).toBeInTheDocument()
+    expect(screen.getByText('共享继承', { selector: '.sm2__stat span' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Skills (2)' }))
+    const inheritedTab = screen.getByRole('button', { name: '共享继承 2' })
+    fireEvent.click(inheritedTab)
+
+    expect(inheritedTab).toHaveClass('active')
+    expect(screen.getByText(/ZCode 默认读取 ~\/.agents\/skills/)).toBeInTheDocument()
+    expect(screen.getAllByText('.agents 共享目录')).toHaveLength(2)
+    expect(screen.getByText('/Users/me/.agents/skills/shared-review')).toBeInTheDocument()
+    const inheritedCard = screen.getByText('shared-review').closest('article')
+    expect(inheritedCard).not.toBeNull()
+    expect(within(inheritedCard!).queryByText('接管')).not.toBeInTheDocument()
+    expect(within(inheritedCard!).queryByText('删除')).not.toBeInTheDocument()
+
+    fireEvent.change(screen.getByPlaceholderText('搜索 Skill 名称 / 路径 / 来源 / 原因'), { target: { value: 'missing-skill' } })
+    expect(screen.getByText('没有找到从 ~/.agents/skills 继承的 Skill。')).toBeInTheDocument()
+    fireEvent.change(screen.getByPlaceholderText('搜索 Skill 名称 / 路径 / 来源 / 原因'), { target: { value: '' } })
+    fireEvent.click(screen.getByText('列表'))
+    expect(container.querySelector('.sm2__agent-skill-list')).not.toBeNull()
+    expect(screen.getByText('/Users/me/.agents/skills/shared-writing')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: '重新扫描此 Agent' }))
+    await waitFor(() => {
+      expect(scan).toHaveBeenCalledWith('zcode')
+      expect(scan).toHaveBeenCalledWith('agents')
+    })
+  })
+
   it('filters managed Agent skills by skill pack membership', async () => {
     useSkillStoreV2.setState({
       selectedAgentDetail: {


### PR DESCRIPTION
## Summary

- project the existing `.agents` shared Skill inventory into ZCode Agent detail as read-only inherited skills
- add a `共享继承` scope, count, source label, and explanation that ZCode reads `~/.agents/skills` by default
- rescan the shared directory when ZCode is rescanned, without creating duplicate targets or mutation actions
- add backend and frontend regression coverage plus all five translations

## Validation

- `pnpm lint`
- `pnpm test:run` (618 tests)
- `pnpm build`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml zcode_agent_detail_projects_shared_skills_as_inherited -- --nocapture`

Closes #76