### PR TITLE
fix: generalize shared skill inheritance

### DIFF
--- a/docs/plans/2026-07-30-shared-skill-consumers-design.md
+++ b/docs/plans/2026-07-30-shared-skill-consumers-design.md
@@ -86,6 +86,11 @@ projection preserves:
 Rows are deduplicated by logical path and sorted by Skill ID. Non-consumers
 receive an empty inherited collection.
 
+Shared discovery also traverses bounded package-manager wrapper directories,
+including `node_modules`, because installed Skill packages can place the real
+`SKILL.md` below a top-level package shell. Canonically identical aliases are
+deduplicated.
+
 Agent-owned scans must not record the global shared root as that Agent's
 unmanaged inventory. OpenClaw still scans its private workspace and built-in
 roots, but the global `~/.agents/skills` root is represented only through the

--- a/docs/plans/2026-07-30-shared-skill-consumers-design.md
+++ b/docs/plans/2026-07-30-shared-skill-consumers-design.md
@@ -1,0 +1,144 @@
+# Shared Skill Consumers Design
+
+## Context
+
+AgentBro inventories `~/.agents/skills` once under the internal `agents`
+source. Several coding agents can load that shared directory in addition to
+their own private Skills directory:
+
+- Codex
+- Kimi Code
+- OpenClaw
+- ZCode
+
+The Agent detail UI currently treats those shared Skills inconsistently.
+ZCode receives a dedicated read-only inherited scope, Codex receives the same
+inventory through a frontend unmanaged-item exception, and Kimi Code and
+OpenClaw do not receive the same presentation.
+
+## Goals
+
+- Represent `~/.agents/skills` as inherited capability for every supported
+  consumer.
+- Keep the shared `agents` inventory as the single source of truth.
+- Keep inherited items visually and behaviorally separate from private,
+  Agent-owned installations.
+- Avoid showing the same shared item as both inherited and unmanaged.
+
+## Non-goals
+
+- Changing how Skills are installed or distributed.
+- Creating one target or unmanaged row per consuming Agent.
+- Supporting project-local `.agents/skills` roots in this change.
+- Inferring shared-directory support from arbitrary folders at runtime.
+
+## Options
+
+### A. Continue frontend Agent-ID exceptions
+
+The frontend can expand the existing `zcode` and `codex` checks to four Agent
+IDs. This is small, but it duplicates capability knowledge across scanning,
+filtering, counts, notices, and rendering. Future consumers can easily drift.
+
+### B. Central backend consumer capability
+
+The backend owns the supported consumer set and returns inherited Skills for
+those Agents. The frontend renders the inherited scope whenever the returned
+field is present for a consumer. Re-scan behavior uses the same consumer
+capability instead of another independent list.
+
+This is the selected approach because the backend already owns Agent path and
+inventory semantics.
+
+### C. Duplicate shared rows into each Agent inventory
+
+Scanning could create unmanaged or target rows for every consumer. This makes
+existing queries simpler, but duplicates ownership, hashes, diagnostics, and
+cleanup actions. It also incorrectly suggests that a shared item belongs to
+each Agent.
+
+## Design
+
+### Capability model
+
+Add one backend predicate for Agents that inherit the global shared directory.
+The initial consumer set is Codex, Kimi Code, OpenClaw, and ZCode.
+
+The predicate is the only policy source used to:
+
+- project shared inventory into `AgentDetail.inherited_skills`;
+- expose whether the selected Agent consumes the shared directory;
+- decide whether a detail re-scan must also refresh the internal `agents`
+  inventory.
+
+The existing `.agents` source remains hidden from the Agent sidebar.
+
+### Backend projection
+
+For a shared consumer, `AgentDetail` receives a read-only projection of skill
+targets and unmanaged items owned by the internal `agents` source. The
+projection preserves:
+
+- the logical path under `~/.agents/skills`;
+- the resolved path when the entry is a symlink;
+- the inferred or managed Skill ID.
+
+Rows are deduplicated by logical path and sorted by Skill ID. Non-consumers
+receive an empty inherited collection.
+
+Agent-owned scans must not record the global shared root as that Agent's
+unmanaged inventory. OpenClaw still scans its private workspace and built-in
+roots, but the global `~/.agents/skills` root is represented only through the
+shared projection.
+
+### Frontend behavior
+
+The Skills total, summary strip, overview capability count, and
+`共享继承` scope use the inherited collection for every supported consumer.
+The scope remains visible with a zero count so users can understand the
+discovery rule before installing shared Skills.
+
+The notice is Agent-aware:
+
+> {{agent}} 默认读取 `~/.agents/skills`。这里展示该共享目录中当前可用的
+> Skill；它们也可能被其他 Agent 使用。此处仅展示继承关系，不会将其视为
+> {{agent}} 私有安装项。
+
+Inherited cards and list rows remain read-only. They support search, paging,
+card/list switching, and opening fallback details, but do not expose adopt,
+delete, distribution, or pack mutation actions.
+
+### Re-scan
+
+Re-scanning a shared consumer refreshes both:
+
+1. the selected Agent's private inventory;
+2. the internal `agents` shared inventory.
+
+The UI then reloads unmanaged inventory, Agent detail, and the overview.
+
+### Compatibility and errors
+
+`inheritedSkills` stays optional in the TypeScript transport type so older or
+remote backends render an empty collection. A missing or unreadable shared
+directory produces zero inherited items through the normal scan behavior.
+
+## Tests
+
+Rust regression tests cover:
+
+- all four consumers receiving direct and symlinked shared Skills;
+- non-consumers receiving no inherited Skills;
+- no duplicate target or unmanaged rows for consumers;
+- consumer capability metadata.
+
+Frontend regression tests cover:
+
+- Codex, Kimi Code, OpenClaw, and ZCode showing the inherited tab and dynamic
+  notice;
+- shared items not appearing under unmanaged;
+- totals, summary, search, and view switching;
+- re-scan refreshing both the selected Agent and `agents`;
+- a non-consumer not showing the inherited scope.
+
+All five locale files are updated together.

--- a/src-tauri/src/skills/v2/agent_meta.rs
+++ b/src-tauri/src/skills/v2/agent_meta.rs
@@ -289,10 +289,15 @@ pub fn agent_skill_dirs(home: &Path, agent: &str) -> Vec<PathBuf> {
         return agent_paths::doubao_skill_dirs_for(home);
     }
     if agent != "openclaw" {
-        if table().iter().all(|m| m.id != agent) {
-            return agent_paths::paths_for_agent(agent).skill_dirs;
+        let mut dirs = if table().iter().all(|m| m.id != agent) {
+            agent_paths::paths_for_agent(agent).skill_dirs
+        } else {
+            agent_skills_dir(home, agent).into_iter().collect()
+        };
+        if inherits_shared_agents_skills(agent) {
+            dirs.push(home.join(".agents").join("skills"));
         }
-        return agent_skills_dir(home, agent).into_iter().collect();
+        return dedupe_paths(dirs);
     }
     let workspace = openclaw_workspace_dir(home);
     let mut dirs = vec![
@@ -304,6 +309,10 @@ pub fn agent_skill_dirs(home: &Path, agent: &str) -> Vec<PathBuf> {
     ];
     dirs.extend(openclaw_bundled_skill_dirs());
     dedupe_paths(dirs)
+}
+
+pub fn inherits_shared_agents_skills(agent: &str) -> bool {
+    matches!(agent, "codex" | "kimi" | "openclaw" | "zcode")
 }
 
 pub fn agent_owned_skill_dirs(home: &Path, agent: &str) -> Vec<PathBuf> {
@@ -520,9 +529,22 @@ mod tests {
             agent_owned_skill_dirs(home, "codex"),
             vec![home.join(".codex/skills")]
         );
+        assert!(agent_skill_dirs(home, "codex")
+            .iter()
+            .any(|path| path == &home.join(".agents/skills")));
         assert!(!agent_owned_skill_dirs(home, "openclaw")
             .iter()
             .any(|path| path == &home.join(".agents/skills")));
+    }
+
+    #[test]
+    fn shared_agents_skill_consumers_are_explicit() {
+        for agent in ["codex", "kimi", "openclaw", "zcode"] {
+            assert!(inherits_shared_agents_skills(agent), "{agent}");
+        }
+        for agent in ["claude-code", "cursor", "gemini", "agents"] {
+            assert!(!inherits_shared_agents_skills(agent), "{agent}");
+        }
     }
 
     #[test]

--- a/src-tauri/src/skills/v2/commands.rs
+++ b/src-tauri/src/skills/v2/commands.rs
@@ -294,12 +294,13 @@ pub fn execute_distribute_skill(
 #[tauri::command(async)]
 pub fn scan_agent_inventory(agent_id: String) -> Result<serde_json::Value, String> {
     let svc = svc()?;
-    let result = svc.scan_one_agent_into_db(&agent_id)?;
+    let result = svc.scan_agent_inventory_into_db(&agent_id)?;
     Ok(serde_json::json!({
         "agentId": agent_id,
         "managed": result.managed,
         "unmanaged": result.unmanaged,
         "readOnly": result.read_only,
+        "includedShared": result.included_shared,
     }))
 }
 

--- a/src-tauri/src/skills/v2/models.rs
+++ b/src-tauri/src/skills/v2/models.rs
@@ -275,6 +275,7 @@ pub struct AgentDetail {
     pub plugin_dir: Option<String>,
     pub agent_dir: Option<String>,
     pub skills: Vec<SkillTargetDetail>,
+    pub inherits_shared_skills: bool,
     pub inherited_skills: Vec<InheritedSkillDetail>,
     pub applied_packs: Vec<AppliedPackSummary>,
     pub available_packs: Vec<SkillPackSummary>,

--- a/src-tauri/src/skills/v2/service.rs
+++ b/src-tauri/src/skills/v2/service.rs
@@ -419,6 +419,7 @@ impl Service {
                 managed: 0,
                 unmanaged: 0,
                 read_only: 0,
+                included_shared: false,
             });
         }
         let now = db::now_iso();
@@ -449,11 +450,21 @@ impl Service {
         let mut unmanaged = 0usize;
         let mut read_only = 0usize;
         let mut seen_skill_ids = BTreeSet::new();
+        let shared_skills_dir = self.home.join(".agents").join("skills");
         for skills_dir in skill_dirs {
+            if agent_meta::inherits_shared_agents_skills(agent_id)
+                && skills_dir == shared_skills_dir
+            {
+                continue;
+            }
             if !skills_dir.is_dir() {
                 continue;
             }
-            let skill_paths = discover_agent_skill_paths(&skills_dir, agent_id == "openclaw")?;
+            let skill_paths = discover_agent_skill_paths(
+                &skills_dir,
+                matches!(agent_id, "openclaw" | SHARED_SKILLS_AGENT_ID),
+                agent_id == SHARED_SKILLS_AGENT_ID,
+            )?;
             for path in skill_paths {
                 let inferred = fsutil::infer_skill_id(&path);
                 if !seen_skill_ids.insert(inferred.clone()) {
@@ -499,7 +510,20 @@ impl Service {
             managed,
             unmanaged,
             read_only,
+            included_shared: false,
         })
+    }
+
+    pub fn scan_agent_inventory_into_db(&self, agent_id: &str) -> Result<AgentScanResult, String> {
+        let mut result = self.scan_one_agent_into_db(agent_id)?;
+        if agent_meta::inherits_shared_agents_skills(agent_id) {
+            let shared = self.scan_one_agent_into_db(SHARED_SKILLS_AGENT_ID)?;
+            result.managed += shared.managed;
+            result.unmanaged += shared.unmanaged;
+            result.read_only += shared.read_only;
+            result.included_shared = true;
+        }
+        Ok(result)
     }
 
     fn ensure_agent_row(&self, agent_id: &str) -> Result<bool, String> {
@@ -5217,6 +5241,7 @@ impl Service {
                 .to_lowercase()
                 .cmp(&right.skill_id.to_lowercase())
         });
+        let inherits_shared_skills = agent_meta::inherits_shared_agents_skills(agent_id);
 
         let applied_packs = self.applied_packs_for_agent(agent_id)?;
         let available_packs = self.list_skill_packs()?;
@@ -5263,6 +5288,7 @@ impl Service {
             plugin_dir,
             agent_dir,
             skills,
+            inherits_shared_skills,
             inherited_skills,
             applied_packs,
             available_packs,
@@ -5276,7 +5302,7 @@ impl Service {
         &self,
         agent_id: &str,
     ) -> Result<Vec<InheritedSkillDetail>, String> {
-        if agent_id != "zcode" {
+        if !agent_meta::inherits_shared_agents_skills(agent_id) {
             return Ok(Vec::new());
         }
         let rows = self.db.with_conn(|connection| {
@@ -5466,6 +5492,7 @@ pub struct AgentScanResult {
     pub managed: usize,
     pub unmanaged: usize,
     pub read_only: usize,
+    pub included_shared: bool,
 }
 
 struct SkillRow {
@@ -6108,15 +6135,33 @@ fn upsert_source(
 
 // silence unused import warning when not needed
 
-fn discover_agent_skill_paths(root: &Path, recursive: bool) -> Result<Vec<PathBuf>, String> {
+fn discover_agent_skill_paths(
+    root: &Path,
+    recursive: bool,
+    include_dependency_dirs: bool,
+) -> Result<Vec<PathBuf>, String> {
     let mut out = Vec::new();
-    discover_agent_skill_paths_inner(root, recursive, 0, &mut out)?;
+    discover_agent_skill_paths_inner(root, recursive, include_dependency_dirs, 0, &mut out)?;
+    out.sort_by(|left, right| {
+        let left_is_link = std::fs::symlink_metadata(left)
+            .map(|metadata| metadata.file_type().is_symlink())
+            .unwrap_or(false);
+        let right_is_link = std::fs::symlink_metadata(right)
+            .map(|metadata| metadata.file_type().is_symlink())
+            .unwrap_or(false);
+        left_is_link
+            .cmp(&right_is_link)
+            .then_with(|| left.cmp(right))
+    });
+    let mut seen = BTreeSet::new();
+    out.retain(|path| seen.insert(path.canonicalize().unwrap_or_else(|_| path.to_path_buf())));
     Ok(out)
 }
 
 fn discover_agent_skill_paths_inner(
     dir: &Path,
     recursive: bool,
+    include_dependency_dirs: bool,
     depth: usize,
     out: &mut Vec<PathBuf>,
 ) -> Result<(), String> {
@@ -6126,7 +6171,9 @@ fn discover_agent_skill_paths_inner(
     let entries = std::fs::read_dir(dir).map_err(|e| e.to_string())?;
     for entry in entries.flatten() {
         let name = entry.file_name().to_string_lossy().to_string();
-        if fsutil::is_ignored_entry(&name) || name.starts_with('.') {
+        let ignored =
+            fsutil::is_ignored_entry(&name) && !(include_dependency_dirs && name == "node_modules");
+        if ignored || name.starts_with('.') {
             continue;
         }
         let path = entry.path();
@@ -6138,7 +6185,13 @@ fn discover_agent_skill_paths_inner(
             continue;
         }
         if recursive {
-            discover_agent_skill_paths_inner(&path, recursive, depth + 1, out)?;
+            discover_agent_skill_paths_inner(
+                &path,
+                recursive,
+                include_dependency_dirs,
+                depth + 1,
+                out,
+            )?;
         }
     }
     Ok(())

--- a/src-tauri/src/skills/v2/tests.rs
+++ b/src-tauri/src/skills/v2/tests.rs
@@ -3764,8 +3764,8 @@ fn agent_detail_reads_zcode_nested_mcp_and_plugins() {
 
 #[test]
 #[cfg(unix)]
-fn zcode_agent_detail_projects_shared_skills_as_inherited() {
-    let (_home, svc, _lock) = fresh_service("zcode-inherited-shared-skills");
+fn shared_skill_consumers_project_shared_skills_as_inherited() {
+    let (_home, svc, _lock) = fresh_service("shared-skill-consumers");
     let shared_root = svc.home.join(".agents/skills");
     let local = write_skill(&shared_root, "shared-local", "shared-local", Some("shared"));
     let source = write_skill(
@@ -3776,22 +3776,38 @@ fn zcode_agent_detail_projects_shared_skills_as_inherited() {
     );
     let linked = shared_root.join("shared-linked");
     std::os::unix::fs::symlink(&source, &linked).unwrap();
+    let nested = write_skill(
+        &shared_root.join("package-wrapper/node_modules/_package@1.0.0"),
+        "nested-shared",
+        "nested-shared",
+        Some("nested"),
+    );
 
-    svc.refresh().unwrap();
+    for agent_id in ["codex", "kimi", "openclaw", "zcode"] {
+        let scan = svc.scan_agent_inventory_into_db(agent_id).unwrap();
+        assert!(scan.included_shared, "{agent_id}");
+        assert!(scan.unmanaged >= 3, "{agent_id}");
 
-    let detail = svc.get_agent_detail("zcode").unwrap();
-    assert!(detail.skills.is_empty());
-    assert_eq!(detail.inherited_skills.len(), 2);
-    assert!(detail.inherited_skills.iter().any(|skill| {
-        skill.skill_id == "shared-local"
-            && skill.path == local.display().to_string()
-            && skill.resolved_path.is_none()
-    }));
-    assert!(detail.inherited_skills.iter().any(|skill| {
-        skill.skill_id == "shared-linked"
-            && skill.path == linked.display().to_string()
-            && skill.resolved_path.as_deref() == Some(source.to_string_lossy().as_ref())
-    }));
+        let detail = svc.get_agent_detail(agent_id).unwrap();
+        assert!(detail.inherits_shared_skills, "{agent_id}");
+        assert!(detail.skills.is_empty(), "{agent_id}");
+        assert_eq!(detail.inherited_skills.len(), 3, "{agent_id}");
+        assert!(detail.inherited_skills.iter().any(|skill| {
+            skill.skill_id == "shared-local"
+                && skill.path == local.display().to_string()
+                && skill.resolved_path.is_none()
+        }));
+        assert!(detail.inherited_skills.iter().any(|skill| {
+            skill.skill_id == "shared-linked"
+                && skill.path == linked.display().to_string()
+                && skill.resolved_path.as_deref() == Some(source.to_string_lossy().as_ref())
+        }));
+        assert!(detail.inherited_skills.iter().any(|skill| {
+            skill.skill_id == "nested-shared"
+                && skill.path == nested.display().to_string()
+                && skill.resolved_path.is_none()
+        }));
+    }
 
     let unmanaged = svc.list_unmanaged().unwrap();
     assert_eq!(
@@ -3799,16 +3815,18 @@ fn zcode_agent_detail_projects_shared_skills_as_inherited() {
             .iter()
             .filter(|item| item.agent_id.as_deref() == Some("agents"))
             .count(),
-        2
+        3
     );
-    assert!(!unmanaged
-        .iter()
-        .any(|item| item.agent_id.as_deref() == Some("zcode")));
-    assert!(svc
-        .get_agent_detail("claude-code")
-        .unwrap()
-        .inherited_skills
-        .is_empty());
+    for agent_id in ["codex", "kimi", "openclaw", "zcode"] {
+        assert!(!unmanaged
+            .iter()
+            .any(|item| item.agent_id.as_deref() == Some(agent_id)
+                && item.path.starts_with(&shared_root.display().to_string())));
+    }
+
+    let non_consumer = svc.get_agent_detail("claude-code").unwrap();
+    assert!(!non_consumer.inherits_shared_skills);
+    assert!(non_consumer.inherited_skills.is_empty());
 }
 
 #[test]

--- a/src/components/skills-v2/AgentManagementPage.tsx
+++ b/src/components/skills-v2/AgentManagementPage.tsx
@@ -288,22 +288,19 @@ export function AgentManagementPage() {
     setNotice(null)
     state.setError(null)
     try {
-      const scanIds = ['codex', 'zcode'].includes(agentId) ? [agentId, SHARED_SKILLS_AGENT_ID] : [agentId]
-      const results = await Promise.all(scanIds.map((id) => skillApiV2.scanAgentInventory(id)))
+      const result = await skillApiV2.scanAgentInventory(agentId)
       const unmanaged = await skillApiV2.listUnmanaged()
       useSkillStoreV2.setState({ unmanaged })
       await state.loadAgentDetail(agentId, true)
       await state.loadOverview(true)
-      const managed = results.reduce((sum, result) => sum + result.managed, 0)
-      const unmanagedCount = results.reduce((sum, result) => sum + result.unmanaged, 0)
-      const readOnlyCount = results.reduce((sum, result) => sum + (result.readOnly ?? 0), 0)
+      const readOnlyCount = result.readOnly ?? 0
       setNotice(t(
         readOnlyCount > 0
           ? 'skills.agentManagement.scanCompleteReadOnly'
-          : scanIds.length > 1
+          : result.includedShared
           ? 'skills.agentManagement.scanCompleteShared'
           : 'skills.agentManagement.scanComplete',
-        { managed, unmanaged: unmanagedCount, readOnly: readOnlyCount },
+        { managed: result.managed, unmanaged: result.unmanaged, readOnly: readOnlyCount },
       ))
     } catch (e) {
       state.setError(String(e))
@@ -1024,10 +1021,11 @@ function AgentDetailView({
 }) {
   const { t } = useTranslation()
   const showUnmanaged = useSkillStoreV2((s) => s.settings?.showUnmanaged ?? true)
-  const observedSkills = useSkillStoreV2((s) => s.unmanaged).filter((u) => unmanagedVisibleForAgent(detail.id, u))
+  const observedSkills = useSkillStoreV2((s) => s.unmanaged).filter((u) => u.agentId === detail.id)
   const unmanaged = observedSkills.filter((item) => showUnmanaged && !isReadOnlyUnmanaged(item))
   const readOnlySkills = observedSkills.filter(isReadOnlyUnmanaged)
   const inheritedSkills = detail.inheritedSkills ?? []
+  const inheritsSharedSkills = detail.inheritsSharedSkills ?? inheritedSkills.length > 0
   const installed = program ? program.status === 'installed' || program.status === 'updateAvailable' : agentInstalled
   const canInstall = Boolean(program?.installCommand)
   const canOpenDownload = Boolean(program?.downloadUrl)
@@ -1071,7 +1069,7 @@ function AgentDetailView({
         <div className="sm2__agent-summary-strip" aria-label="Agent 摘要">
           <Stat value={detail.skills.length} label="已管理" />
           {showUnmanaged && <Stat value={unmanaged.length} label="未管理" tone={unmanaged.length > 0 ? 'warn' : 'ok'} />}
-          {detail.id === 'zcode' && <Stat value={inheritedSkills.length} label={t('skills.agentManagement.inheritedSkills')} />}
+          {inheritsSharedSkills && <Stat value={inheritedSkills.length} label={t('skills.agentManagement.inheritedSkills')} />}
           {readOnlySkills.length > 0 && <Stat value={readOnlySkills.length} label={t('skills.agentManagement.builtinSkills')} />}
           <Stat value={detail.appliedPacks.length} label="技能包" />
           <Stat value={detail.mcpServers.length + detail.plugins.length} label="MCP/插件" />
@@ -1492,6 +1490,7 @@ function SkillsTab({
   const [confirmingPackApply, setConfirmingPackApply] = useState(false)
   const [packApplyProgress, setPackApplyProgress] = useState<PackApplyProgress | null>(null)
   const [localNotice, setLocalNotice] = useState<string | null>(null)
+  const inheritsSharedSkills = detail.inheritsSharedSkills ?? inheritedSkills.length > 0
   const q = query.trim().toLowerCase()
   const searchedManaged = useMemo(() => {
     if (!q) return detail.skills
@@ -1580,8 +1579,8 @@ function SkillsTab({
   }, [detail.id, packFilter, scope])
 
   useEffect(() => {
-    if (scope === 'inherited' && detail.id !== 'zcode') setScope('managed')
-  }, [detail.id, scope])
+    if (scope === 'inherited' && !inheritsSharedSkills) setScope('managed')
+  }, [detail.id, inheritsSharedSkills, scope])
 
   useEffect(() => {
     if (!localNotice) return
@@ -1904,7 +1903,7 @@ function SkillsTab({
             未管理 {filteredUnmanaged.length}
           </button>
         )}
-        {detail.id === 'zcode' && (
+        {inheritsSharedSkills && (
           <button
             className={scope === 'inherited' ? 'active' : ''}
             aria-selected={scope === 'inherited'}
@@ -2133,10 +2132,10 @@ function SkillsTab({
         </>
       )}
 
-      {scope === 'inherited' && detail.id === 'zcode' && (
+      {scope === 'inherited' && inheritsSharedSkills && (
         <>
           <div className="sm2__notice sm2__notice--info">
-            {t('skills.agentManagement.inheritedSkillsNotice')}
+            {t('skills.agentManagement.inheritedSkillsNotice', { agent: detail.displayName })}
           </div>
           {filteredInherited.length === 0 ? (
             <div className="sm2__empty sm2__empty--compact">
@@ -3642,11 +3641,6 @@ function defaultAgentDetailAdoptMode(item: UnmanagedItemDto) {
 
 function adoptOwnerAgentId(detailAgentId: string, item: UnmanagedItemDto) {
   return item.agentId || detailAgentId
-}
-
-function unmanagedVisibleForAgent(agentId: string, item: UnmanagedItemDto) {
-  if (item.agentId === agentId) return true
-  return agentId === 'codex' && item.agentId === SHARED_SKILLS_AGENT_ID
 }
 
 function isSharedAgentsUnmanaged(item: UnmanagedItemDto) {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1224,7 +1224,7 @@
       },
       "inheritedSkills": "Inherited",
       "inheritedSkillsSource": ".agents shared directory",
-      "inheritedSkillsNotice": "ZCode reads ~/.agents/skills by default. This list shows Skills currently available from that shared directory; Codex, Kimi, and other Agents may use them too. This view only shows inheritance and does not treat them as private ZCode installations.",
+      "inheritedSkillsNotice": "{{agent}} reads ~/.agents/skills by default. This list shows Skills currently available from that shared directory; other Agents may use them too. This view only shows inheritance and does not treat them as private {{agent}} installations.",
       "inheritedSkillsNoResults": "No Skills inherited from ~/.agents/skills were found.",
       "builtinSkills": "Built-in",
       "builtinSkillsNotice": "{{count}} Skills are provided by {{agent}} and shown read-only. AgentBro will not adopt, overwrite, or delete these files.",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1225,7 +1225,7 @@
       },
       "inheritedSkills": "共有継承",
       "inheritedSkillsSource": ".agents 共有ディレクトリ",
-      "inheritedSkillsNotice": "ZCode はデフォルトで ~/.agents/skills を読み込みます。ここには共有ディレクトリから現在利用できる Skill が表示され、Codex、Kimi などの Agent でも同時に使用される場合があります。この画面は継承関係のみを表示し、ZCode 固有のインストールとしては扱いません。",
+      "inheritedSkillsNotice": "{{agent}} はデフォルトで ~/.agents/skills を読み込みます。ここには共有ディレクトリから現在利用できる Skill が表示され、他の Agent でも使用される場合があります。この画面は継承関係のみを表示し、{{agent}} 固有のインストールとしては扱いません。",
       "inheritedSkillsNoResults": "~/.agents/skills から継承された Skill が見つかりません。",
       "builtinSkills": "組み込み",
       "builtinSkillsNotice": "{{count}} 個の Skill は {{agent}} が提供する組み込み機能で、読み取り専用で表示されます。AgentBro はこれらのファイルを引き継ぎ、上書き、削除しません。",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1225,7 +1225,7 @@
       },
       "inheritedSkills": "공유 상속",
       "inheritedSkillsSource": ".agents 공유 디렉터리",
-      "inheritedSkillsNotice": "ZCode는 기본적으로 ~/.agents/skills를 읽습니다. 여기에는 공유 디렉터리에서 현재 사용할 수 있는 Skill이 표시되며 Codex, Kimi 등의 Agent에서도 함께 사용할 수 있습니다. 이 화면은 상속 관계만 표시하며 ZCode 전용 설치로 취급하지 않습니다.",
+      "inheritedSkillsNotice": "{{agent}}는 기본적으로 ~/.agents/skills를 읽습니다. 여기에는 공유 디렉터리에서 현재 사용할 수 있는 Skill이 표시되며 다른 Agent에서도 함께 사용할 수 있습니다. 이 화면은 상속 관계만 표시하며 {{agent}} 전용 설치로 취급하지 않습니다.",
       "inheritedSkillsNoResults": "~/.agents/skills에서 상속된 Skill을 찾을 수 없습니다.",
       "builtinSkills": "기본 제공",
       "builtinSkillsNotice": "{{count}}개의 Skill은 {{agent}}에서 기본 제공하며 읽기 전용으로 표시됩니다. AgentBro는 이 파일을 인계, 덮어쓰기 또는 삭제하지 않습니다.",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -1073,7 +1073,7 @@
       },
       "inheritedSkills": "Paylaşılan miras",
       "inheritedSkillsSource": ".agents paylaşılan dizini",
-      "inheritedSkillsNotice": "ZCode varsayılan olarak ~/.agents/skills dizinini okur. Burada paylaşılan dizinden kullanılabilen Skill'ler gösterilir; Codex, Kimi ve diğer Agent'lar da bunları kullanabilir. Bu görünüm yalnızca miras ilişkisini gösterir ve bunları ZCode'a özel kurulumlar olarak değerlendirmez.",
+      "inheritedSkillsNotice": "{{agent}} varsayılan olarak ~/.agents/skills dizinini okur. Burada paylaşılan dizinden kullanılabilen Skill'ler gösterilir; diğer Agent'lar da bunları kullanabilir. Bu görünüm yalnızca miras ilişkisini gösterir ve bunları {{agent}} özel kurulumları olarak değerlendirmez.",
       "inheritedSkillsNoResults": "~/.agents/skills dizininden miras alınan Skill bulunamadı.",
       "builtinSkills": "Yerleşik",
       "builtinSkillsNotice": "{{count}} Skill, {{agent}} tarafından sağlanır ve salt okunur gösterilir. AgentBro bu dosyaları devralmaz, üzerlerine yazmaz veya silmez.",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1265,7 +1265,7 @@
       },
       "inheritedSkills": "共享继承",
       "inheritedSkillsSource": ".agents 共享目录",
-      "inheritedSkillsNotice": "ZCode 默认读取 ~/.agents/skills。这里展示该共享目录中当前可用的 Skill；它们可能同时被 Codex、Kimi 等 Agent 使用。此处仅展示继承关系，不会将其视为 ZCode 私有安装项。",
+      "inheritedSkillsNotice": "{{agent}} 默认读取 ~/.agents/skills。这里展示该共享目录中当前可用的 Skill；它们也可能被其他 Agent 使用。此处仅展示继承关系，不会将其视为 {{agent}} 私有安装项。",
       "inheritedSkillsNoResults": "没有找到从 ~/.agents/skills 继承的 Skill。",
       "builtinSkills": "内置",
       "builtinSkillsNotice": "{{count}} 个 Skill 由 {{agent}} 内置提供，仅作只读展示。AgentBro 不会接管、覆盖或删除这些文件。",

--- a/src/services/skillApiV2.ts
+++ b/src/services/skillApiV2.ts
@@ -426,6 +426,7 @@ export interface AgentDetail {
   pluginDir: string | null
   agentDir?: string | null
   skills: SkillTargetDetail[]
+  inheritsSharedSkills?: boolean
   inheritedSkills?: InheritedSkillDetail[]
   appliedPacks: AppliedPackSummary[]
   availablePacks: SkillPackSummary[]
@@ -1223,8 +1224,8 @@ export const skillApiV2 = {
 
   scanAgentInventory: (agentId: string) =>
     isTauriRuntime()
-      ? invoke<{ agentId: string; managed: number; unmanaged: number; readOnly?: number }>('scan_agent_inventory', { agentId })
-      : Promise.resolve({ agentId, managed: 0, unmanaged: 0, readOnly: 0 }),
+      ? invoke<{ agentId: string; managed: number; unmanaged: number; readOnly?: number; includedShared?: boolean }>('scan_agent_inventory', { agentId })
+      : Promise.resolve({ agentId, managed: 0, unmanaged: 0, readOnly: 0, includedShared: false }),
 
   previewAdopt: (agentId: string, unmanagedId: string) =>
     isTauriRuntime() ? invoke<AdoptPreview>('preview_adopt_agent_skill', { agentId, unmanagedId }) : Promise.resolve(null as unknown as AdoptPreview),

--- a/src/test/skillManagerV2View.test.tsx
+++ b/src/test/skillManagerV2View.test.tsx
@@ -3324,14 +3324,20 @@ describe('Skill detail slider + agent page render without crashing', () => {
     expect(container.querySelector('.sm2__agent-skill-list')).not.toBeNull()
   })
 
-  it('shows ZCode shared skills in a read-only inherited scope', async () => {
-    const zcodeDetail: AgentDetail = {
+  it.each([
+    { id: 'codex', displayName: 'Codex', skillsDir: '/Users/me/.codex/skills' },
+    { id: 'kimi', displayName: 'Kimi Code', skillsDir: '/Users/me/.kimi-code/skills' },
+    { id: 'openclaw', displayName: 'OpenClaw', skillsDir: '/Users/me/.openclaw/workspace/skills' },
+    { id: 'zcode', displayName: 'ZCode', skillsDir: '/Users/me/.zcode/skills' },
+  ])('shows $displayName shared skills in a read-only inherited scope', async ({ id, displayName, skillsDir }) => {
+    const consumerDetail: AgentDetail = {
       ...agentDetail,
-      id: 'zcode',
-      displayName: 'ZCode',
-      iconKey: 'zcode',
-      skillsDir: '/Users/me/.zcode/skills',
+      id,
+      displayName,
+      iconKey: id,
+      skillsDir,
       skills: [],
+      inheritsSharedSkills: true,
       inheritedSkills: [
         {
           id: 'unmanaged-shared-review',
@@ -3349,19 +3355,30 @@ describe('Skill detail slider + agent page render without crashing', () => {
     }
     useSkillStoreV2.setState({
       agents: [
-        { id: 'zcode', displayName: 'ZCode', iconKey: 'zcode', enabled: true, skillsDir: '/Users/me/.zcode/skills', version: '3.5.3', latestVersion: null, installed: true, managedSkillCount: 0, unmanagedSkillCount: 0 } as AgentSummary,
+        { id, displayName, iconKey: id, enabled: true, skillsDir, version: '3.5.3', latestVersion: null, installed: true, managedSkillCount: 0, unmanagedSkillCount: 0 } as AgentSummary,
       ],
-      selectedAgentId: 'zcode',
-      selectedAgentDetail: zcodeDetail,
-      unmanaged: [],
+      selectedAgentId: id,
+      selectedAgentDetail: consumerDetail,
+      unmanaged: [
+        {
+          id: 'shared-source-item',
+          agentId: 'agents',
+          itemType: 'skill',
+          path: '/Users/me/.agents/skills/shared-source-item',
+          inferredSkillId: 'shared-source-item',
+          hash: null,
+          reason: 'shared_agents_directory',
+        },
+      ],
     })
     const scan = vi.spyOn(skillApiV2, 'scanAgentInventory').mockImplementation(async (agentId) => ({
       agentId,
       managed: 0,
-      unmanaged: agentId === 'agents' ? 2 : 0,
+      unmanaged: 2,
+      includedShared: true,
     }))
     vi.spyOn(skillApiV2, 'listUnmanaged').mockResolvedValue([])
-    vi.spyOn(skillApiV2, 'getAgentDetail').mockResolvedValue(zcodeDetail)
+    vi.spyOn(skillApiV2, 'getAgentDetail').mockResolvedValue(consumerDetail)
     vi.spyOn(skillApiV2, 'overview').mockResolvedValue(makeOverview())
 
     const { AgentManagementPage } = await import('../components/skills-v2/AgentManagementPage')
@@ -3370,11 +3387,13 @@ describe('Skill detail slider + agent page render without crashing', () => {
     expect(screen.getByRole('button', { name: 'Skills (2)' })).toBeInTheDocument()
     expect(screen.getByText('共享继承', { selector: '.sm2__stat span' })).toBeInTheDocument()
     fireEvent.click(screen.getByRole('button', { name: 'Skills (2)' }))
+    fireEvent.click(screen.getByRole('button', { name: '未管理 0' }))
+    expect(screen.queryByText('shared-source-item')).not.toBeInTheDocument()
     const inheritedTab = screen.getByRole('button', { name: '共享继承 2' })
     fireEvent.click(inheritedTab)
 
     expect(inheritedTab).toHaveClass('active')
-    expect(screen.getByText(/ZCode 默认读取 ~\/.agents\/skills/)).toBeInTheDocument()
+    expect(screen.getByText(new RegExp(`${displayName} 默认读取 ~\\/.agents\\/skills`))).toBeInTheDocument()
     expect(screen.getAllByText('.agents 共享目录')).toHaveLength(2)
     expect(screen.getByText('/Users/me/.agents/skills/shared-review')).toBeInTheDocument()
     const inheritedCard = screen.getByText('shared-review').closest('article')
@@ -3391,9 +3410,75 @@ describe('Skill detail slider + agent page render without crashing', () => {
 
     fireEvent.click(screen.getByRole('button', { name: '重新扫描此 Agent' }))
     await waitFor(() => {
-      expect(scan).toHaveBeenCalledWith('zcode')
-      expect(scan).toHaveBeenCalledWith('agents')
+      expect(scan).toHaveBeenCalledTimes(1)
+      expect(scan).toHaveBeenCalledWith(id)
     })
+  })
+
+  it('keeps the inherited scope visible for a consumer with an empty shared directory', async () => {
+    useSkillStoreV2.setState({
+      agents: [
+        {
+          id: 'codex',
+          displayName: 'Codex',
+          iconKey: 'codex',
+          enabled: true,
+          skillsDir: '/Users/me/.codex/skills',
+          version: null,
+          latestVersion: null,
+          installed: true,
+          managedSkillCount: 1,
+          unmanagedSkillCount: 0,
+        } as AgentSummary,
+      ],
+      selectedAgentId: 'codex',
+      selectedAgentDetail: {
+        ...agentDetail,
+        id: 'codex',
+        displayName: 'Codex',
+        iconKey: 'codex',
+        skillsDir: '/Users/me/.codex/skills',
+        inheritsSharedSkills: true,
+        inheritedSkills: [],
+      },
+      unmanaged: [],
+    })
+
+    const { AgentManagementPage } = await import('../components/skills-v2/AgentManagementPage')
+    render(<AgentManagementPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Skills (1)' }))
+    fireEvent.click(screen.getByRole('button', { name: '共享继承 0' }))
+    expect(screen.getByText(/Codex 默认读取 ~\/.agents\/skills/)).toBeInTheDocument()
+    expect(screen.getByText('没有找到从 ~/.agents/skills 继承的 Skill。')).toBeInTheDocument()
+  })
+
+  it('does not expose shared inventory as inherited or unmanaged for a non-consumer', async () => {
+    useSkillStoreV2.setState({
+      selectedAgentDetail: {
+        ...agentDetail,
+        inheritsSharedSkills: false,
+        inheritedSkills: [],
+      },
+      unmanaged: [
+        {
+          id: 'shared-source-item',
+          agentId: 'agents',
+          itemType: 'skill',
+          path: '/Users/me/.agents/skills/shared-source-item',
+          inferredSkillId: 'shared-source-item',
+          hash: null,
+          reason: 'shared_agents_directory',
+        },
+      ],
+    })
+
+    const { AgentManagementPage } = await import('../components/skills-v2/AgentManagementPage')
+    render(<AgentManagementPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Skills (1)' }))
+    expect(screen.queryByRole('button', { name: /共享继承/ })).not.toBeInTheDocument()
+    expect(screen.queryByText('shared-source-item')).not.toBeInTheDocument()
   })
 
   it('filters managed Agent skills by skill pack membership', async () => {
@@ -3817,15 +3902,15 @@ describe('Skill detail slider + agent page render without crashing', () => {
     expect(loadOverview).toHaveBeenCalledWith(true)
   })
 
-  it('uses the shared owner and keeps deletion errors visible inside the confirmation dialog', async () => {
-    const sharedItem = {
-      id: 'unmanaged-shared-bird',
-      agentId: 'agents',
+  it('keeps unmanaged deletion errors visible inside the confirmation dialog', async () => {
+    const codexItem = {
+      id: 'unmanaged-codex-bird',
+      agentId: 'codex',
       itemType: 'skill' as const,
-      path: '/Users/me/.agents/skills/bird',
+      path: '/Users/me/.codex/skills/bird',
       inferredSkillId: 'bird',
       hash: null,
-      reason: 'shared_agents_directory',
+      reason: 'not_in_center_library',
     }
     useSkillStoreV2.setState({
       selectedAgentId: 'codex',
@@ -3839,10 +3924,10 @@ describe('Skill detail slider + agent page render without crashing', () => {
       agents: [
         { id: 'codex', displayName: 'Codex', iconKey: 'codex', enabled: true, skillsDir: '/Users/me/.codex/skills', version: null, latestVersion: null, installed: true, managedSkillCount: 1, unmanagedSkillCount: 1 } as AgentSummary,
       ],
-      unmanaged: [sharedItem],
+      unmanaged: [codexItem],
     })
     const mismatch = new Error(
-      "Unmanaged item 'unmanaged-shared-bird' does not belong to agent 'agents'.",
+      "Unmanaged item 'unmanaged-codex-bird' does not belong to agent 'codex'.",
     )
     const deleteUnmanaged = vi.spyOn(skillApiV2, 'deleteUnmanagedAgentSkill').mockRejectedValue(mismatch)
     const { AgentManagementPage } = await import('../components/skills-v2/AgentManagementPage')
@@ -3855,8 +3940,8 @@ describe('Skill detail slider + agent page render without crashing', () => {
     expect(dialog).toHaveClass('sm2__modal--unmanaged-delete')
     fireEvent.click(within(dialog).getByRole('button', { name: '直接删除' }))
 
-    await waitFor(() => expect(deleteUnmanaged).toHaveBeenCalledWith('agents', 'unmanaged-shared-bird'))
-    expect(await within(dialog).findByText('该未管理 Skill 不属于 Agent「agents」，请重新扫描后重试。')).toBeInTheDocument()
+    await waitFor(() => expect(deleteUnmanaged).toHaveBeenCalledWith('codex', 'unmanaged-codex-bird'))
+    expect(await within(dialog).findByText('该未管理 Skill 不属于 Agent「codex」，请重新扫描后重试。')).toBeInTheDocument()
     expect(useSkillStoreV2.getState().error).toBeNull()
   })
 


### PR DESCRIPTION
## Summary

- model `~/.agents/skills` as read-only inherited capability for Codex, Kimi Code, OpenClaw, and ZCode
- remove shared inventory duplication from Agent-owned unmanaged Skills
- refresh shared inventory inside the backend Agent scan command
- discover nested package-managed Skills under shared `node_modules` wrappers and deduplicate aliases
- render an Agent-aware inherited tab, count, empty state, and notice across all consumers

## Validation

- `pnpm lint`
- `pnpm test:run` (53 files, 623 tests)
- `pnpm build`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- targeted Rust shared-consumer and nested-discovery regression

Closes #79