### PR TITLE
fix: allow deleting shared unmanaged skills

### DIFF
--- a/src-tauri/src/skills/v2/agent_meta.rs
+++ b/src-tauri/src/skills/v2/agent_meta.rs
@@ -310,6 +310,9 @@ pub fn agent_owned_skill_dirs(home: &Path, agent: &str) -> Vec<PathBuf> {
     if agent == "doubao" {
         return vec![agent_paths::doubao_user_skills_dir_for(home)];
     }
+    if agent == "agents" {
+        return vec![home.join(".agents").join("skills")];
+    }
     if agent == "openclaw" {
         return vec![
             openclaw_workspace_dir(home).join("skills"),
@@ -514,8 +517,12 @@ mod tests {
     }
 
     #[test]
-    fn owned_skill_dirs_exclude_shared_agent_roots() {
+    fn owned_skill_dirs_include_shared_inventory_root() {
         let home = Path::new("/Users/tester");
+        assert_eq!(
+            agent_owned_skill_dirs(home, "agents"),
+            vec![home.join(".agents/skills")]
+        );
         assert_eq!(
             agent_owned_skill_dirs(home, "codex"),
             vec![home.join(".codex/skills")]

--- a/src-tauri/src/skills/v2/tests.rs
+++ b/src-tauri/src/skills/v2/tests.rs
@@ -2817,6 +2817,74 @@ fn delete_unmanaged_agent_skill_removes_local_copy_without_importing_center() {
 }
 
 #[test]
+fn delete_unmanaged_agents_skill_removes_shared_copy() {
+    let (_home, svc, _lock) = fresh_service("delete-unmanaged-shared-agent");
+    let shared = write_skill(
+        &svc.home.join(".agents/skills"),
+        "shared",
+        "shared-skill",
+        Some("v1"),
+    );
+    svc.refresh().unwrap();
+    let unmanaged = svc
+        .list_unmanaged()
+        .unwrap()
+        .into_iter()
+        .find(|u| u.agent_id.as_deref() == Some("agents") && u.path == shared.display().to_string())
+        .expect("shared unmanaged skill found");
+
+    svc.delete_unmanaged_agent_skill("agents", &unmanaged.id)
+        .unwrap();
+
+    assert!(!shared.exists());
+    assert!(svc
+        .list_unmanaged()
+        .unwrap()
+        .iter()
+        .all(|u| u.id != unmanaged.id));
+}
+
+#[test]
+fn delete_unmanaged_agents_skill_rejects_shared_root_and_outside_paths() {
+    let (_home, svc, _lock) = fresh_service("delete-unmanaged-shared-boundary");
+    let shared_root = svc.home.join(".agents/skills");
+    let shared = write_skill(&shared_root, "shared", "shared-skill", Some("v1"));
+    let outside = write_skill(
+        &svc.home.join("Documents"),
+        "outside",
+        "outside-skill",
+        Some("v1"),
+    );
+    svc.refresh().unwrap();
+    let unmanaged = svc
+        .list_unmanaged()
+        .unwrap()
+        .into_iter()
+        .find(|u| u.agent_id.as_deref() == Some("agents") && u.path == shared.display().to_string())
+        .expect("shared unmanaged skill found");
+
+    for unsafe_path in [&shared_root, &outside] {
+        svc.db()
+            .with_conn(|connection| {
+                connection
+                    .execute(
+                        "UPDATE unmanaged_items SET path = ?1 WHERE id = ?2",
+                        params![unsafe_path.display().to_string(), unmanaged.id],
+                    )
+                    .map_err(|error| error.to_string())
+            })
+            .unwrap();
+
+        let error = svc
+            .delete_unmanaged_agent_skill("agents", &unmanaged.id)
+            .unwrap_err();
+
+        assert!(error.contains("outside 'agents' skill roots"));
+        assert!(unsafe_path.exists());
+    }
+}
+
+#[test]
 fn delete_unmanaged_agent_skill_rejects_wrong_agent() {
     let (_home, svc, _lock) = fresh_service("delete-unmanaged-wrong-agent");
     let rogue = write_skill(


### PR DESCRIPTION
## Summary

- treat the virtual `agents` inventory as the owner of `~/.agents/skills` for destructive path validation
- preserve the existing root, outside-path, read-only, ownership, and symlink safety checks
- add regression coverage for allowed shared child deletion and rejected unsafe paths

## Validation

- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo test --manifest-path src-tauri/Cargo.toml delete_unmanaged_agents_skill`
- `cargo test --manifest-path src-tauri/Cargo.toml owned_skill_dirs_include_shared_inventory_root`
- `pnpm lint`
- `pnpm test:run`
- `pnpm build`
- `cargo check --manifest-path src-tauri/Cargo.toml`

Closes #80