### PR TITLE
fix: separate Agent and shared scan counts

### DIFF
--- a/src-tauri/src/skills/v2/commands.rs
+++ b/src-tauri/src/skills/v2/commands.rs
@@ -301,6 +301,9 @@ pub fn scan_agent_inventory(agent_id: String) -> Result<serde_json::Value, Strin
         "unmanaged": result.unmanaged,
         "readOnly": result.read_only,
         "includedShared": result.included_shared,
+        "sharedManaged": result.shared_managed,
+        "sharedUnmanaged": result.shared_unmanaged,
+        "sharedReadOnly": result.shared_read_only,
     }))
 }
 

--- a/src-tauri/src/skills/v2/service.rs
+++ b/src-tauri/src/skills/v2/service.rs
@@ -420,6 +420,9 @@ impl Service {
                 unmanaged: 0,
                 read_only: 0,
                 included_shared: false,
+                shared_managed: 0,
+                shared_unmanaged: 0,
+                shared_read_only: 0,
             });
         }
         let now = db::now_iso();
@@ -511,6 +514,9 @@ impl Service {
             unmanaged,
             read_only,
             included_shared: false,
+            shared_managed: 0,
+            shared_unmanaged: 0,
+            shared_read_only: 0,
         })
     }
 
@@ -518,10 +524,10 @@ impl Service {
         let mut result = self.scan_one_agent_into_db(agent_id)?;
         if agent_meta::inherits_shared_agents_skills(agent_id) {
             let shared = self.scan_one_agent_into_db(SHARED_SKILLS_AGENT_ID)?;
-            result.managed += shared.managed;
-            result.unmanaged += shared.unmanaged;
-            result.read_only += shared.read_only;
             result.included_shared = true;
+            result.shared_managed = shared.managed;
+            result.shared_unmanaged = shared.unmanaged;
+            result.shared_read_only = shared.read_only;
         }
         Ok(result)
     }
@@ -5493,6 +5499,9 @@ pub struct AgentScanResult {
     pub unmanaged: usize,
     pub read_only: usize,
     pub included_shared: bool,
+    pub shared_managed: usize,
+    pub shared_unmanaged: usize,
+    pub shared_read_only: usize,
 }
 
 struct SkillRow {

--- a/src-tauri/src/skills/v2/tests.rs
+++ b/src-tauri/src/skills/v2/tests.rs
@@ -3834,6 +3834,12 @@ fn agent_detail_reads_zcode_nested_mcp_and_plugins() {
 #[cfg(unix)]
 fn shared_skill_consumers_project_shared_skills_as_inherited() {
     let (_home, svc, _lock) = fresh_service("shared-skill-consumers");
+    let codex_private = write_skill(
+        &svc.home.join(".codex/skills"),
+        "codex-private",
+        "codex-private",
+        Some("private"),
+    );
     let shared_root = svc.home.join(".agents/skills");
     let local = write_skill(&shared_root, "shared-local", "shared-local", Some("shared"));
     let source = write_skill(
@@ -3852,9 +3858,15 @@ fn shared_skill_consumers_project_shared_skills_as_inherited() {
     );
 
     for agent_id in ["codex", "kimi", "openclaw", "zcode"] {
+        let agent_only = svc.scan_one_agent_into_db(agent_id).unwrap();
         let scan = svc.scan_agent_inventory_into_db(agent_id).unwrap();
         assert!(scan.included_shared, "{agent_id}");
-        assert!(scan.unmanaged >= 3, "{agent_id}");
+        assert_eq!(scan.managed, agent_only.managed, "{agent_id}");
+        assert_eq!(scan.unmanaged, agent_only.unmanaged, "{agent_id}");
+        assert_eq!(scan.read_only, agent_only.read_only, "{agent_id}");
+        assert_eq!(scan.shared_managed, 0, "{agent_id}");
+        assert_eq!(scan.shared_unmanaged, 3, "{agent_id}");
+        assert_eq!(scan.shared_read_only, 0, "{agent_id}");
 
         let detail = svc.get_agent_detail(agent_id).unwrap();
         assert!(detail.inherits_shared_skills, "{agent_id}");
@@ -3878,6 +3890,10 @@ fn shared_skill_consumers_project_shared_skills_as_inherited() {
     }
 
     let unmanaged = svc.list_unmanaged().unwrap();
+    assert!(unmanaged.iter().any(|item| {
+        item.agent_id.as_deref() == Some("codex")
+            && item.path == codex_private.display().to_string()
+    }));
     assert_eq!(
         unmanaged
             .iter()

--- a/src/components/skills-v2/AgentManagementPage.tsx
+++ b/src/components/skills-v2/AgentManagementPage.tsx
@@ -294,13 +294,23 @@ export function AgentManagementPage() {
       await state.loadAgentDetail(agentId, true)
       await state.loadOverview(true)
       const readOnlyCount = result.readOnly ?? 0
+      const sharedReadOnlyCount = result.sharedReadOnly ?? 0
       setNotice(t(
-        readOnlyCount > 0
+        result.includedShared
+          ? readOnlyCount > 0 || sharedReadOnlyCount > 0
+            ? 'skills.agentManagement.scanCompleteSharedReadOnly'
+            : 'skills.agentManagement.scanCompleteShared'
+          : readOnlyCount > 0
           ? 'skills.agentManagement.scanCompleteReadOnly'
-          : result.includedShared
-          ? 'skills.agentManagement.scanCompleteShared'
           : 'skills.agentManagement.scanComplete',
-        { managed: result.managed, unmanaged: result.unmanaged, readOnly: readOnlyCount },
+        {
+          managed: result.managed,
+          unmanaged: result.unmanaged,
+          readOnly: readOnlyCount,
+          sharedManaged: result.sharedManaged ?? 0,
+          sharedUnmanaged: result.sharedUnmanaged ?? 0,
+          sharedReadOnly: sharedReadOnlyCount,
+        },
       ))
     } catch (e) {
       state.setError(String(e))

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1156,7 +1156,8 @@
     },
     "agentManagement": {
       "scanComplete": "Scan complete: {{managed}} managed, {{unmanaged}} unmanaged",
-      "scanCompleteShared": "Scan complete (including the .agents shared directory): {{managed}} managed, {{unmanaged}} unmanaged",
+      "scanCompleteShared": "Scan complete: this Agent has {{managed}} managed and {{unmanaged}} unmanaged; the .agents shared directory has {{sharedManaged}} managed and {{sharedUnmanaged}} unmanaged",
+      "scanCompleteSharedReadOnly": "Scan complete: this Agent has {{managed}} managed, {{unmanaged}} unmanaged, and {{readOnly}} built-in read-only; the .agents shared directory has {{sharedManaged}} managed, {{sharedUnmanaged}} unmanaged, and {{sharedReadOnly}} read-only",
       "scanCompleteReadOnly": "Scan complete: {{managed}} managed, {{unmanaged}} unmanaged, {{readOnly}} built-in read-only",
       "sharedDirectoryNotice": "{{count}} Skills are from the .agents shared directory. After adoption, they will be moved into the center library and removed from the shared directory. Manage future distribution through the center library or skill packs.",
       "pathSettings": {

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1157,7 +1157,8 @@
     },
     "agentManagement": {
       "scanComplete": "スキャン完了：管理済み {{managed}}、未管理 {{unmanaged}}",
-      "scanCompleteShared": "スキャン完了（.agents 共有ディレクトリを含む）：管理済み {{managed}}、未管理 {{unmanaged}}",
+      "scanCompleteShared": "スキャン完了：この Agent は管理済み {{managed}}、未管理 {{unmanaged}}；.agents 共有ディレクトリは管理済み {{sharedManaged}}、未管理 {{sharedUnmanaged}}",
+      "scanCompleteSharedReadOnly": "スキャン完了：この Agent は管理済み {{managed}}、未管理 {{unmanaged}}、組み込み読み取り専用 {{readOnly}}；.agents 共有ディレクトリは管理済み {{sharedManaged}}、未管理 {{sharedUnmanaged}}、読み取り専用 {{sharedReadOnly}}",
       "scanCompleteReadOnly": "スキャン完了：管理済み {{managed}}、未管理 {{unmanaged}}、組み込み読み取り専用 {{readOnly}}",
       "sharedDirectoryNotice": "{{count}} 個の Skill は .agents 共有ディレクトリにあります。引き継ぎ後はセンターライブラリに移動し、共有ディレクトリから削除されます。以後はセンターライブラリまたはスキルパックから配布を管理してください。",
       "pathSettings": {

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1157,7 +1157,8 @@
     },
     "agentManagement": {
       "scanComplete": "스캔 완료: 관리됨 {{managed}}, 관리되지 않음 {{unmanaged}}",
-      "scanCompleteShared": "스캔 완료(.agents 공유 디렉터리 포함): 관리됨 {{managed}}, 관리되지 않음 {{unmanaged}}",
+      "scanCompleteShared": "스캔 완료: 이 Agent는 관리됨 {{managed}}, 관리되지 않음 {{unmanaged}}; .agents 공유 디렉터리는 관리됨 {{sharedManaged}}, 관리되지 않음 {{sharedUnmanaged}}",
+      "scanCompleteSharedReadOnly": "스캔 완료: 이 Agent는 관리됨 {{managed}}, 관리되지 않음 {{unmanaged}}, 기본 제공 읽기 전용 {{readOnly}}; .agents 공유 디렉터리는 관리됨 {{sharedManaged}}, 관리되지 않음 {{sharedUnmanaged}}, 읽기 전용 {{sharedReadOnly}}",
       "scanCompleteReadOnly": "스캔 완료: 관리됨 {{managed}}, 관리되지 않음 {{unmanaged}}, 기본 제공 읽기 전용 {{readOnly}}",
       "sharedDirectoryNotice": "{{count}}개의 Skill이 .agents 공유 디렉터리에 있습니다. 인계 후 중앙 라이브러리로 이동되고 공유 디렉터리에서는 제거됩니다. 이후 배포는 중앙 라이브러리 또는 스킬 팩에서 관리하세요.",
       "pathSettings": {

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -1005,7 +1005,8 @@
     },
     "agentManagement": {
       "scanComplete": "Tarama tamamlandı: {{managed}} yönetilen, {{unmanaged}} yönetilmeyen",
-      "scanCompleteShared": "Tarama tamamlandı (.agents paylaşılan dizini dahil): {{managed}} yönetilen, {{unmanaged}} yönetilmeyen",
+      "scanCompleteShared": "Tarama tamamlandı: bu Agent için {{managed}} yönetilen ve {{unmanaged}} yönetilmeyen; .agents paylaşılan dizininde {{sharedManaged}} yönetilen ve {{sharedUnmanaged}} yönetilmeyen",
+      "scanCompleteSharedReadOnly": "Tarama tamamlandı: bu Agent için {{managed}} yönetilen, {{unmanaged}} yönetilmeyen ve {{readOnly}} yerleşik salt okunur; .agents paylaşılan dizininde {{sharedManaged}} yönetilen, {{sharedUnmanaged}} yönetilmeyen ve {{sharedReadOnly}} salt okunur",
       "scanCompleteReadOnly": "Tarama tamamlandı: {{managed}} yönetilen, {{unmanaged}} yönetilmeyen, {{readOnly}} yerleşik salt okunur",
       "sharedDirectoryNotice": "{{count}} Skill .agents paylaşılan dizininden geliyor. Devralındıktan sonra merkez kütüphaneye taşınır ve paylaşılan dizinden kaldırılır. Sonraki dağıtımları merkez kütüphane veya Skill paketleri üzerinden yönetin.",
       "pathSettings": {

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1197,7 +1197,8 @@
     },
     "agentManagement": {
       "scanComplete": "扫描完成：已管理 {{managed}}，未管理 {{unmanaged}}",
-      "scanCompleteShared": "扫描完成（含 .agents 共享目录）：已管理 {{managed}}，未管理 {{unmanaged}}",
+      "scanCompleteShared": "扫描完成：此 Agent 已管理 {{managed}}，未管理 {{unmanaged}}；.agents 共享目录已管理 {{sharedManaged}}，未管理 {{sharedUnmanaged}}",
+      "scanCompleteSharedReadOnly": "扫描完成：此 Agent 已管理 {{managed}}，未管理 {{unmanaged}}，内置只读 {{readOnly}}；.agents 共享目录已管理 {{sharedManaged}}，未管理 {{sharedUnmanaged}}，只读 {{sharedReadOnly}}",
       "scanCompleteReadOnly": "扫描完成：已管理 {{managed}}，未管理 {{unmanaged}}，内置只读 {{readOnly}}",
       "sharedDirectoryNotice": "{{count}} 个 Skill 来自 .agents 共享目录。接管后会进入中心库，并从共享目录清理；后续请通过中心库或技能包控制分发。",
       "pathSettings": {

--- a/src/services/skillApiV2.ts
+++ b/src/services/skillApiV2.ts
@@ -1224,8 +1224,26 @@ export const skillApiV2 = {
 
   scanAgentInventory: (agentId: string) =>
     isTauriRuntime()
-      ? invoke<{ agentId: string; managed: number; unmanaged: number; readOnly?: number; includedShared?: boolean }>('scan_agent_inventory', { agentId })
-      : Promise.resolve({ agentId, managed: 0, unmanaged: 0, readOnly: 0, includedShared: false }),
+      ? invoke<{
+          agentId: string
+          managed: number
+          unmanaged: number
+          readOnly?: number
+          includedShared?: boolean
+          sharedManaged?: number
+          sharedUnmanaged?: number
+          sharedReadOnly?: number
+        }>('scan_agent_inventory', { agentId })
+      : Promise.resolve({
+          agentId,
+          managed: 0,
+          unmanaged: 0,
+          readOnly: 0,
+          includedShared: false,
+          sharedManaged: 0,
+          sharedUnmanaged: 0,
+          sharedReadOnly: 0,
+        }),
 
   previewAdopt: (agentId: string, unmanagedId: string) =>
     isTauriRuntime() ? invoke<AdoptPreview>('preview_adopt_agent_skill', { agentId, unmanagedId }) : Promise.resolve(null as unknown as AdoptPreview),

--- a/src/test/skillManagerV2View.test.tsx
+++ b/src/test/skillManagerV2View.test.tsx
@@ -3417,7 +3417,7 @@ describe('Skill detail slider + agent page render without crashing', () => {
       expect(scan).toHaveBeenCalledTimes(1)
       expect(scan).toHaveBeenCalledWith(id)
     })
-    expect(screen.getByText(
+    expect(await screen.findByText(
       '扫描完成：此 Agent 已管理 0，未管理 0；.agents 共享目录已管理 0，未管理 2',
     )).toBeInTheDocument()
   })

--- a/src/test/skillManagerV2View.test.tsx
+++ b/src/test/skillManagerV2View.test.tsx
@@ -3374,8 +3374,12 @@ describe('Skill detail slider + agent page render without crashing', () => {
     const scan = vi.spyOn(skillApiV2, 'scanAgentInventory').mockImplementation(async (agentId) => ({
       agentId,
       managed: 0,
-      unmanaged: 2,
+      unmanaged: 0,
+      readOnly: 0,
       includedShared: true,
+      sharedManaged: 0,
+      sharedUnmanaged: 2,
+      sharedReadOnly: 0,
     }))
     vi.spyOn(skillApiV2, 'listUnmanaged').mockResolvedValue([])
     vi.spyOn(skillApiV2, 'getAgentDetail').mockResolvedValue(consumerDetail)
@@ -3413,6 +3417,9 @@ describe('Skill detail slider + agent page render without crashing', () => {
       expect(scan).toHaveBeenCalledTimes(1)
       expect(scan).toHaveBeenCalledWith(id)
     })
+    expect(screen.getByText(
+      '扫描完成：此 Agent 已管理 0，未管理 0；.agents 共享目录已管理 0，未管理 2',
+    )).toBeInTheDocument()
   })
 
   it('keeps the inherited scope visible for a consumer with an empty shared directory', async () => {


### PR DESCRIPTION
## Summary

- keep selected-Agent scan counts separate from the virtual `.agents` shared inventory
- return shared managed, unmanaged, and read-only counts explicitly
- label Agent and shared-directory counts independently in scan completion notices
- preserve the read-only shared inheritance scope without duplicating shared Skills under Agent-owned unmanaged
- add Rust and frontend regressions and update all five locales

## Validation

- `pnpm lint`
- `pnpm test:run` (623 tests)
- `pnpm build`
- `cargo check --manifest-path src-tauri/Cargo.toml`

Closes #83