### PR TITLE
ci: skip installer builds for dev pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main, master, develop]
   pull_request:
-    branches: [dev, main, master]
+    branches: [main, master]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- stop triggering the full platform Build workflow for pull requests targeting `dev`
- keep macOS and Windows packaging for pull requests targeting `main` or `master`
- preserve existing push and manual Build triggers
- keep frontend and backend PR CI unchanged

## Validation

- parsed `.github/workflows/build.yml` with Ruby YAML
- `pnpm lint`
- `pnpm test:run`
- `pnpm build`
- `cargo check --manifest-path src-tauri/Cargo.toml`

## Repository setting

After opening this PR, remove the three platform Build contexts from `dev` required status checks. Keep `main` protection unchanged.

Closes #85