### PR TITLE
fix: prevent Windows background console popups

### DIFF
--- a/src-tauri/src/agents/codex.rs
+++ b/src-tauri/src/agents/codex.rs
@@ -6,7 +6,7 @@ use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
 use std::net::{SocketAddr, TcpStream};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Output, Stdio};
+use std::process::{Output, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -229,7 +229,7 @@ pub fn probe_app_server_readiness() -> CodexAppServerProbe {
 }
 
 fn run_command_with_timeout(binary: &Path, args: &[&str], timeout: Duration) -> Option<Output> {
-    let mut child = Command::new(binary)
+    let mut child = crate::platform::process::background_command(binary)
         .args(args)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/src-tauri/src/agents/codex_app_server.rs
+++ b/src-tauri/src/agents/codex_app_server.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use tokio::io::{AsyncBufReadExt, BufReader as TokioBufReader};
 use tokio::net::TcpStream;
-use tokio::process::{Child, Command as TokioCommand};
+use tokio::process::Child;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
 
@@ -29,7 +29,7 @@ pub async fn spawn_and_connect_app_server(
     binary: &Path,
     startup_timeout: Duration,
 ) -> Result<CodexAppServerConnection, String> {
-    let mut command = TokioCommand::new(binary);
+    let mut command = crate::platform::process::background_tokio_command(binary);
     command
         .arg("app-server")
         .arg("--listen")

--- a/src-tauri/src/agents/copilot.rs
+++ b/src-tauri/src/agents/copilot.rs
@@ -26,7 +26,7 @@ impl CopilotAdapter {
     fn is_installed() -> bool {
         // Check for gh CLI with copilot extension
         if let Some(gh_path) = super::executable::find_binary("gh") {
-            return std::process::Command::new(gh_path)
+            return crate::platform::process::background_command(gh_path)
                 .args(["copilot", "--version"])
                 .output()
                 .map(|o| o.status.success())

--- a/src-tauri/src/agents/detection.rs
+++ b/src-tauri/src/agents/detection.rs
@@ -116,7 +116,7 @@ fn detect_copilot() -> DetectedTool {
     let config_dir = find_config_dir(&[".config/github-copilot"]);
 
     let copilot_available = gh_path.as_ref().is_some_and(|path| {
-        std::process::Command::new(path)
+        crate::platform::process::background_command(path)
             .args(["copilot", "--version"])
             .output()
             .map(|o| o.status.success())

--- a/src-tauri/src/agents/executable.rs
+++ b/src-tauri/src/agents/executable.rs
@@ -246,7 +246,7 @@ fn which_all(binary: &str) -> Vec<PathBuf> {
     #[cfg(not(target_os = "windows"))]
     let command = "which";
 
-    std::process::Command::new(command)
+    crate::platform::process::background_command(command)
         .arg(binary)
         .output()
         .ok()
@@ -293,7 +293,7 @@ pub fn interactive_login_shell_vars(vars: &[&str]) -> Vec<(String, String)> {
         return Vec::new();
     }
     let shell = user_shell();
-    let output = match std::process::Command::new(&shell)
+    let output = match crate::platform::process::background_command(&shell)
         .args(["-lic", "env"])
         .stdin(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
@@ -318,7 +318,7 @@ fn shell_var(var: &str, interactive: bool) -> Option<String> {
     let shell = user_shell();
     let cmd = shell_var_fallback_cmd(var);
     let shell_mode = if interactive { "-lic" } else { "-lc" };
-    let output = std::process::Command::new(&shell)
+    let output = crate::platform::process::background_command(&shell)
         .args([shell_mode, &cmd])
         .stdin(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
@@ -342,7 +342,7 @@ fn login_shell_path() -> Option<Vec<PathBuf>> {
     } else {
         "printf '%s' \"$PATH\""
     };
-    let output = std::process::Command::new(shell)
+    let output = crate::platform::process::background_command(shell)
         .args(["-lc", cmd])
         .stdin(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())

--- a/src-tauri/src/agents/hook_manager.rs
+++ b/src-tauri/src/agents/hook_manager.rs
@@ -371,7 +371,7 @@ fn bridge_candidate_is_fresh(bridge: &Path) -> bool {
 fn bridge_candidate_can_run(bridge: &Path) -> bool {
     #[cfg(target_os = "windows")]
     {
-        return std::process::Command::new(bridge)
+        return crate::platform::process::background_command(bridge)
             .arg("--version")
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::null())

--- a/src-tauri/src/bridge/main.rs
+++ b/src-tauri/src/bridge/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
 //! AgentBro Hook Bridge
 //!
 //! A lightweight compiled binary that Claude Code hooks call.

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -39,7 +39,7 @@ use futures_util::{SinkExt, StreamExt};
 use tauri::{Manager, State};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader as TokioBufReader};
 use tokio::net::TcpStream;
-use tokio::process::{Child, ChildStdin, ChildStdout, Command as TokioCommand};
+use tokio::process::{Child, ChildStdin, ChildStdout};
 use tokio::sync::{mpsc, oneshot, Mutex as TokioMutex};
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{MaybeTlsStream, WebSocketStream};
@@ -870,7 +870,7 @@ async fn load_codex_usage_rate_limits_live_uncached() -> Option<UsageRateLimitSn
     }
 
     let binary = find_binary("codex")?;
-    let mut child = TokioCommand::new(binary)
+    let mut child = crate::platform::process::background_tokio_command(binary)
         .args(["-s", "read-only", "-a", "untrusted", "app-server"])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -3737,7 +3737,7 @@ async fn submit_codex_request_user_input_output(
         .ok_or_else(|| "Could not find codex CLI for app-server".to_string())?;
     let output = codex_request_user_input_output(answers);
 
-    let mut child = TokioCommand::new(binary)
+    let mut child = crate::platform::process::background_tokio_command(binary)
         .arg("app-server")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -5332,27 +5332,31 @@ fn set_launch_at_login_state(enabled: bool) -> Result<(), String> {
         let exe = std::env::current_exe()
             .map_err(|err| format!("Unable to resolve current executable: {err}"))?;
         let command = format!("\"{}\"", exe.display());
-        let output = std::process::Command::new(crate::agents::executable::command_path("reg"))
-            .args([
-                "add",
-                WINDOWS_RUN_KEY,
-                "/v",
-                WINDOWS_RUN_VALUE,
-                "/t",
-                "REG_SZ",
-                "/d",
-                &command,
-                "/f",
-            ])
-            .output()
-            .map_err(|err| format!("Failed to update Windows startup registry: {err}"))?;
+        let output = crate::platform::process::background_command(
+            crate::agents::executable::command_path("reg"),
+        )
+        .args([
+            "add",
+            WINDOWS_RUN_KEY,
+            "/v",
+            WINDOWS_RUN_VALUE,
+            "/t",
+            "REG_SZ",
+            "/d",
+            &command,
+            "/f",
+        ])
+        .output()
+        .map_err(|err| format!("Failed to update Windows startup registry: {err}"))?;
         return reg_output_result(output, "Failed to enable Windows launch at login");
     }
 
-    let output = std::process::Command::new(crate::agents::executable::command_path("reg"))
-        .args(["delete", WINDOWS_RUN_KEY, "/v", WINDOWS_RUN_VALUE, "/f"])
-        .output()
-        .map_err(|err| format!("Failed to update Windows startup registry: {err}"))?;
+    let output = crate::platform::process::background_command(
+        crate::agents::executable::command_path("reg"),
+    )
+    .args(["delete", WINDOWS_RUN_KEY, "/v", WINDOWS_RUN_VALUE, "/f"])
+    .output()
+    .map_err(|err| format!("Failed to update Windows startup registry: {err}"))?;
     if output.status.success() || !get_launch_at_login_state() {
         Ok(())
     } else {
@@ -5390,7 +5394,7 @@ fn get_launch_at_login_state() -> bool {
 
 #[cfg(target_os = "windows")]
 fn get_launch_at_login_state() -> bool {
-    std::process::Command::new(crate::agents::executable::command_path("reg"))
+    crate::platform::process::background_command(crate::agents::executable::command_path("reg"))
         .args(["query", WINDOWS_RUN_KEY, "/v", WINDOWS_RUN_VALUE])
         .output()
         .map(|output| output.status.success())

--- a/src-tauri/src/commands/monitor.rs
+++ b/src-tauri/src/commands/monitor.rs
@@ -414,10 +414,12 @@ fn windows_path_eq(left: &str, right: &str) -> bool {
 #[cfg(target_os = "windows")]
 fn read_windows_user_path() -> Result<String, String> {
     let script = "[Environment]::GetEnvironmentVariable('Path', 'User')";
-    let output = std::process::Command::new(crate::agents::executable::command_path("powershell"))
-        .args(["-NoProfile", "-NonInteractive", "-Command", script])
-        .output()
-        .map_err(|e| format!("Failed to read user PATH: {e}"))?;
+    let output = crate::platform::process::background_command(
+        crate::agents::executable::command_path("powershell"),
+    )
+    .args(["-NoProfile", "-NonInteractive", "-Command", script])
+    .output()
+    .map_err(|e| format!("Failed to read user PATH: {e}"))?;
     if !output.status.success() {
         return Err(String::from_utf8_lossy(&output.stderr).trim().to_string());
     }
@@ -432,10 +434,12 @@ fn write_windows_user_path(value: &str) -> Result<(), String> {
         "[Environment]::SetEnvironmentVariable('Path', {}, 'User')",
         powershell_literal(value)
     );
-    let output = std::process::Command::new(crate::agents::executable::command_path("powershell"))
-        .args(["-NoProfile", "-NonInteractive", "-Command", &script])
-        .output()
-        .map_err(|e| format!("Failed to update user PATH: {e}"))?;
+    let output = crate::platform::process::background_command(
+        crate::agents::executable::command_path("powershell"),
+    )
+    .args(["-NoProfile", "-NonInteractive", "-Command", &script])
+    .output()
+    .map_err(|e| format!("Failed to update user PATH: {e}"))?;
     if output.status.success() {
         Ok(())
     } else {

--- a/src-tauri/src/platform/mod.rs
+++ b/src-tauri/src/platform/mod.rs
@@ -5,3 +5,4 @@ pub mod display_controller;
 pub mod idle;
 pub mod monitor_tracker;
 pub mod notifications;
+pub mod process;

--- a/src-tauri/src/platform/process.rs
+++ b/src-tauri/src/platform/process.rs
@@ -1,0 +1,37 @@
+use std::ffi::OsStr;
+
+#[cfg(target_os = "windows")]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+pub fn background_command<S: AsRef<OsStr>>(program: S) -> std::process::Command {
+    let mut command = std::process::Command::new(program);
+    configure_background_command(&mut command);
+    command
+}
+
+pub fn background_tokio_command<S: AsRef<OsStr>>(program: S) -> tokio::process::Command {
+    let mut command = tokio::process::Command::new(program);
+    configure_background_tokio_command(&mut command);
+    command
+}
+
+fn configure_background_command(command: &mut std::process::Command) {
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    let _ = command;
+}
+
+fn configure_background_tokio_command(command: &mut tokio::process::Command) {
+    #[cfg(target_os = "windows")]
+    {
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    let _ = command;
+}


### PR DESCRIPTION
## Summary

- mark the release hook bridge as a Windows GUI-subsystem binary
- centralize hidden background process creation with `CREATE_NO_WINDOW`
- apply the hidden process policy to startup detection, hook diagnostics, Codex app-server probes, launch-at-login registry access, and Windows PATH checks
- preserve the existing `CREATE_NEW_CONSOLE` behavior for explicit terminal launches

## Root cause

The main AgentBro executable already uses the Windows GUI subsystem, but several automatic probes launched console-subsystem child processes without `CREATE_NO_WINDOW`. The separately packaged `agentbro-bridge.exe` was also built as a console binary. Opening AgentBro or its Integration page therefore created one or more visible console windows, and usage polling could repeat the behavior.

## User impact

Automatic startup, Integration diagnostics, hook bridge checks, and Codex usage polling no longer open command windows on Windows. User-requested terminal launches remain visible.

## Validation

- `pnpm lint`
- `pnpm test:run` (53 files, 623 tests)
- `pnpm build`
- `cargo fmt --manifest-path src-tauri/Cargo.toml -- --check`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`
- `cargo test --manifest-path src-tauri/Cargo.toml --bin agentbro-bridge` (19 tests)

Closes #78
