### PR TITLE
fix: reuse Agent Skill controls for shared inheritance

### DIFF
--- a/docs/superpowers/specs/2026-08-03-shared-agent-skill-control-reuse-design.md
+++ b/docs/superpowers/specs/2026-08-03-shared-agent-skill-control-reuse-design.md
@@ -1,0 +1,272 @@
+# Shared Agent Skill Control Reuse Design
+
+## Context
+
+Issue #92 corrects an incomplete reuse introduced by the previous shared-Skill
+UI work. Agent-specific managed and unmanaged Skills use
+`ManagedSkillCollection` and `UnmanagedSkillCollection`, while inherited
+Skills still pass through `InheritedSkillCollection`. The inherited collection
+renders the same low-level card shell but owns a different set of actions and
+states. As a result, shared managed Skills have no delete action and shared
+unmanaged Skills have a one-off adoption action instead of the standard
+management controls.
+
+Shared inheritance is a data-source dimension, not a separate kind of Skill
+management UI. This design removes the inherited-only rendering path and sends
+shared data through the same managed and unmanaged collections used by an
+Agent's private directory.
+
+This document supersedes the read-only shared-presentation restriction in
+`2026-07-31-layered-agent-skill-scopes-design.md`. It does not change that
+document's source/status tab model.
+
+## Goals
+
+- Remove the inherited-only collection and action rendering path.
+- Represent shared managed and unmanaged entries with the existing complete
+  `SkillTargetDetail` and `UnmanagedItemDto` contracts.
+- Reuse the same managed/unmanaged collections, cards, list rows, search,
+  selection, paging, busy states, and error behavior for both sources.
+- Provide single and batch deletion for shared managed and unmanaged Skills.
+- Keep shared adoption on the standard unmanaged collection path.
+- Make every shared destructive confirmation explain its global impact.
+- Preserve the center-library Skill when a managed shared distribution is
+  removed.
+- Protect `~/.agents/skills` mutations with strict owner and path validation.
+
+## Non-goals
+
+- Adding an `全部` status tab.
+- Adding another shared-specific card, list, toolbar, or collection component.
+- Allowing center-library distribution, skill-pack application, or direct
+  target-to-pack moves to the virtual `agents` owner. The backend deliberately
+  rejects `agents` as a distribution target today, and defining shared pack
+  application semantics is a separate product decision.
+- Changing the existing adoption rule that moves an unmanaged shared Skill
+  into the center library and removes its original shared entry.
+- Redesigning the Agent management page outside the Skills tab.
+
+## Alternatives Considered
+
+### Add delete actions to `InheritedSkillCollection`
+
+This is the smallest patch, but it preserves two rendering and behavior paths.
+Future card, list, accessibility, and loading-state changes would continue to
+drift. It is rejected.
+
+### Synthesize standard frontend DTOs from `InheritedSkillDetail`
+
+The current inherited DTO does not contain target mode, status, hashes,
+timestamps, claims, unmanaged reason, or owner metadata. Filling those fields
+with frontend defaults would make the cards look reusable while presenting
+incorrect state and breaking pack/filter behavior. It is rejected.
+
+### Return complete standard DTOs and use one collection path
+
+This is the selected approach. The backend projects shared rows as complete
+managed targets and unmanaged items. The frontend selects an active source and
+passes those arrays to the existing collections. Source-specific behavior is
+expressed only through callbacks and capabilities.
+
+## Data Contract
+
+`InheritedSkillDetail` is removed from the Agent detail contract. A consuming
+Agent receives two source-specific arrays whose element types already exist:
+
+```text
+inheritedManagedSkills: SkillTargetDetail[]
+inheritedUnmanagedSkills: UnmanagedItemDto[]
+```
+
+Every managed entry contains its real `agents` target data, including
+`actualMode`, `status`, hashes, timestamps, and claims. Every unmanaged entry
+contains its real unmanaged ID, owner `agentId = "agents"`, path, inferred Skill
+ID, hash, reason, and read-only flag. The frontend must not manufacture missing
+fields or parse composite IDs.
+
+The backend keeps deterministic normalized-path deduplication. If stale data
+contains both a managed target and an unmanaged row for the same shared path,
+the managed target wins. Both arrays are sorted by Skill name and path so all
+consuming Agents receive a stable projection.
+
+Non-consuming Agents return empty arrays and `inheritsSharedSkills = false`.
+
+## Frontend Architecture
+
+`SkillsTab` keeps the orthogonal state introduced by the layered-source work:
+
+```text
+source: agent | shared
+status: managed | unmanaged | builtin
+```
+
+It derives source-neutral active collections:
+
+```text
+activeManagedSkills = agent source
+  ? detail.skills
+  : detail.inheritedManagedSkills
+
+activeUnmanagedSkills = agent source
+  ? agent-owned unmanaged items
+  : detail.inheritedUnmanagedSkills
+```
+
+Search, counts, filtering, paging, selection, and action state operate on the
+active arrays. Rendering has one managed branch that calls
+`ManagedSkillCollection` and one unmanaged branch that calls
+`UnmanagedSkillCollection`. `InheritedSkillCollection` and
+`openInheritedSkill` are deleted.
+
+The existing `ManagedSkillCard`, `ManagedSkillListRow`, and unmanaged card/list
+rendering remain the only domain-level presentation. Card and list actions keep
+their current event propagation, keyboard, busy, and accessibility behavior.
+
+The source notice remains above the shared collection to explain that the
+selected Agent reads `~/.agents/skills` by default.
+
+## Capability Model
+
+Using the same component does not send unsupported mutations to a different
+owner. The common surface receives capabilities derived from the active
+source:
+
+| Capability | Agent managed | Shared managed | Agent unmanaged | Shared unmanaged |
+| --- | --- | --- | --- | --- |
+| Search and card/list view | Yes | Yes | Yes | Yes |
+| Single delete | Yes | Yes | Yes | Yes |
+| Multi-select and batch delete | Yes | Yes | Yes | Yes |
+| Adopt to center | N/A | N/A | Yes | Yes |
+| Batch adopt | N/A | N/A | Yes | Yes |
+| Skill-pack filter | Yes | Yes, using real claims | N/A | N/A |
+| Add/distribute center Skill | Yes | No | N/A | N/A |
+| Move direct target into pack | Yes | No | N/A | N/A |
+| Apply/revoke pack rail | Yes | No | N/A | N/A |
+| Quick takeover of center duplicate | N/A | N/A | Yes | No |
+
+Unsupported controls are omitted by capability props on the same toolbar and
+collection path. They are not replaced with shared-only JSX. Shared batch
+adoption uses the normal batch adoption flow with each item's real owner set to
+`agents` and the existing `import_cleanup` default.
+
+## Deletion Semantics
+
+### Shared managed Skill
+
+The standard managed card/list delete action opens a source-aware destructive
+confirmation before calling `deleteSkillTargetDistributions` with the real
+target ID.
+
+The confirmation states that:
+
+- the entry will be removed from `~/.agents/skills`;
+- every Agent inheriting that directory will stop seeing it;
+- the center-library Skill is preserved and can be distributed again later.
+
+Batch deletion uses the same API and confirmation semantics for all selected
+shared target IDs. Partial failures remain visible through the existing failure
+result and leave failed entries selected or available for retry.
+
+### Shared unmanaged Skill
+
+The standard unmanaged card/list exposes both `接管` and `删除`. Delete opens a
+source-aware confirmation before calling `deleteUnmanagedAgentSkill` or its
+batch variant with owner `agents` and the real unmanaged ID.
+
+The confirmation states that the original directory under
+`~/.agents/skills` will be permanently removed, all inheriting Agents are
+affected, and the Skill is not copied to the center library. Adoption remains
+the safe alternative when the user wants to keep the Skill.
+
+Single-item failures keep the dialog open and display the error inline. Batch
+failures use the existing per-item result handling.
+
+## Filesystem Safety
+
+Shared deletion is a global mutation and must fail closed. Before removing a
+managed or unmanaged shared path, the backend verifies:
+
+- the database row belongs to owner `agents`;
+- the path is strictly below `~/.agents/skills`, never the root itself;
+- normalized traversal cannot escape the owned root;
+- neither the shared root nor its `.agents` parent is a symbolic link;
+- a leaf symbolic link is allowed, but deletion unlinks only the leaf and never
+  deletes its resolved target.
+
+Managed deletion adds this validation before `remove_target_completely` touches
+the filesystem. Unmanaged shared deletion uses the same strict shared-path
+predicate instead of the more permissive generic Agent predicate. Validation
+failure preserves both the filesystem entry and database row.
+
+Non-shared target deletion keeps its current behavior in this focused change.
+
+## Refresh and Error Handling
+
+After a successful shared mutation, the page refreshes global unmanaged
+inventory, the selected Agent detail, and overview counts. The active source
+and status stay selected. Because every consumer derives its shared projection
+from owner `agents`, the next detail load for Codex, Kimi Code, OpenClaw, or
+ZCode reflects the same mutation.
+
+An API failure does not optimistically remove a card. Busy state is scoped to
+the affected IDs, destructive controls cannot be double-submitted, and action
+buttons do not open the detail panel through event bubbling.
+
+## Localization
+
+New confirmation titles, global-impact explanations, preservation text, and
+success/error labels are added together in all five locale files:
+
+- English
+- Chinese
+- Japanese
+- Korean
+- Turkish
+
+Existing generic action labels are reused where their meaning is unchanged.
+
+## Tests
+
+Frontend regression coverage verifies:
+
+- shared managed entries use the standard managed card and list behavior;
+- shared unmanaged entries use the standard unmanaged card and list behavior;
+- `InheritedSkillCollection` is no longer part of the render path;
+- both shared states expose single delete in card and list modes;
+- shared managed deletion waits for global confirmation and sends the real
+  target ID;
+- shared unmanaged deletion waits for global confirmation and sends owner
+  `agents` plus the real unmanaged ID;
+- shared managed/unmanaged multi-select and batch actions use the standard
+  controls;
+- adoption and delete actions do not open Skill details;
+- managed deletion preserves the center-library explanation, while unmanaged
+  deletion explains permanent removal;
+- failures retain the item and restore usable controls;
+- the four shared consumers retain the two-layer tabs, while non-consumers do
+  not gain a source row;
+- empty, search, paging, runtime-switch, and five-locale behavior remain
+  covered.
+
+Rust regression coverage verifies:
+
+- shared projection returns complete `SkillTargetDetail` and
+  `UnmanagedItemDto` values with real claims and owner IDs;
+- managed rows win normalized-path deduplication;
+- deleting a shared managed leaf removes its target/link and database target
+  while preserving the center Skill;
+- deleting a shared unmanaged leaf removes only the shared source and does not
+  import it;
+- root, outside-root, traversal, and symlinked-parent paths are rejected for
+  both shared managed and unmanaged deletion;
+- deleting a leaf symlink removes only the link;
+- batch deletion reports partial failure without deleting rejected paths;
+- all consumers lose the deleted shared projection and non-consumers remain
+  unaffected.
+
+## Delivery Constraints
+
+- No new dependency.
+- No brand, release, signing, or generated-file changes.
+- All required frontend and Rust checks must pass before the Issue #92 pull
+  request is merged into `dev`.

--- a/src-tauri/src/remote/skill_manager.py
+++ b/src-tauri/src/remote/skill_manager.py
@@ -21,6 +21,8 @@ ARGS = REQUEST.get("args") or {}
 HOME = pathlib.Path.home().resolve()
 STATE_PATH = HOME / ".agentbro" / "skill-manager-remote.json"
 FIXED_CENTER_PATH = HOME / ".agentbro" / "skills"
+SHARED_SKILLS_AGENT_ID = "agents"
+SHARED_SKILL_CONSUMERS = ("codex", "kimi", "openclaw")
 STATE_MUTATING_COMMANDS = {
     "skill_manager_bootstrap",
     "skill_manager_init",
@@ -34,6 +36,12 @@ STATE_MUTATING_COMMANDS = {
     "execute_adopt_agent_skill",
     "execute_adopt_agent_skills",
     "takeover_center_agent_skills",
+    "delete_unmanaged_agent_skill",
+    "delete_unmanaged_agent_skills",
+    "delete_skill_target_distribution",
+    "delete_skill_target_distributions",
+    "execute_sync_copy_target",
+    "execute_fix_diagnosis_issue",
     "execute_upsert_skill_pack",
     "execute_delete_skill_pack",
     "execute_apply_skill_pack",
@@ -565,6 +573,270 @@ def remove_path(path):
         shutil.rmtree(path)
 
 
+def path_present(path):
+    path = pathlib.Path(path)
+    return path.exists() or path.is_symlink()
+
+
+def verified_skill_hash(path, label):
+    path = pathlib.Path(path)
+    try:
+        if not path.is_dir() or not (path / "SKILL.md").is_file():
+            raise ValueError(label + " is not a readable Skill directory")
+        result = hash_dir(path)
+    except (OSError, RuntimeError) as error:
+        raise ValueError(label + " could not be verified") from error
+    if not result:
+        raise ValueError(label + " could not be verified")
+    return result
+
+
+def independent_center_skill_hash(path):
+    path = pathlib.Path(path)
+    try:
+        if (
+            FIXED_CENTER_PATH.is_symlink()
+            or normalized_lexical_path(path.parent)
+            != normalized_lexical_path(FIXED_CENTER_PATH)
+            or path.is_symlink()
+            or not path.is_dir()
+            or (path / "SKILL.md").is_symlink()
+        ):
+            return None
+        if any(item.is_symlink() for item in path.rglob("*")):
+            return None
+        return verified_skill_hash(path, "Center Skill")
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+
+def atomic_replace_skill_directory(source, destination, after_replace=None):
+    source = pathlib.Path(source)
+    destination = pathlib.Path(destination)
+    expected_hash = verified_skill_hash(source, "Source Skill")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    recovery_root = pathlib.Path(tempfile.mkdtemp(
+        prefix=".shared-skill-replace-",
+        dir=str(destination.parent),
+    ))
+    staged = recovery_root / "staged"
+    backup = recovery_root / "backup"
+    failed_replacement = recovery_root / "failed-replacement"
+    keep_recovery = False
+    had_destination = path_present(destination)
+    try:
+        shutil.copytree(source, staged, symlinks=False)
+        if (
+            verified_skill_hash(staged, "Staged Skill") != expected_hash
+            or verified_skill_hash(source, "Source Skill") != expected_hash
+        ):
+            raise ValueError("Source Skill changed while its replacement was staged")
+        if had_destination:
+            os.replace(str(destination), str(backup))
+        try:
+            os.replace(str(staged), str(destination))
+            if verified_skill_hash(destination, "Replaced Skill") != expected_hash:
+                raise ValueError("Replaced Skill failed final verification")
+            if after_replace is not None:
+                after_replace()
+        except Exception as replace_error:
+            rollback_errors = []
+            if path_present(destination):
+                try:
+                    os.replace(str(destination), str(failed_replacement))
+                except Exception as error:
+                    rollback_errors.append("new destination could not be retained: " + str(error))
+            if had_destination:
+                if path_present(destination):
+                    rollback_errors.append("old destination is blocked by the new destination")
+                elif path_present(backup):
+                    try:
+                        os.replace(str(backup), str(destination))
+                    except Exception as error:
+                        rollback_errors.append("old destination could not be restored: " + str(error))
+                else:
+                    rollback_errors.append("old destination backup is missing")
+            elif path_present(destination):
+                rollback_errors.append("new destination could not be rolled back")
+            source_restored = False
+            try:
+                source_restored = (
+                    verified_skill_hash(source, "Source Skill") == expected_hash
+                )
+            except ValueError:
+                pass
+            if rollback_errors or not source_restored:
+                keep_recovery = True
+                detail = "; ".join(rollback_errors)
+                if not source_restored:
+                    detail = (detail + "; " if detail else "") + "source requires recovery"
+                raise ValueError(
+                    "Atomic Skill replacement failed. Recovery artifacts retained at "
+                    + str(recovery_root)
+                    + ": "
+                    + str(replace_error)
+                    + ("; " + detail if detail else "")
+                ) from replace_error
+            raise
+        if path_present(backup):
+            try:
+                remove_path(backup)
+            except Exception as cleanup_error:
+                keep_recovery = True
+                raise ValueError(
+                    "Atomic Skill replacement succeeded but its old destination backup "
+                    "could not be cleaned. Recovery artifacts retained at "
+                    + str(recovery_root)
+                    + ": "
+                    + str(cleanup_error)
+                ) from cleanup_error
+        return expected_hash
+    finally:
+        if recovery_root.exists() and not keep_recovery:
+            try:
+                shutil.rmtree(recovery_root)
+            except OSError:
+                pass
+
+
+def shared_skills_path():
+    return HOME / ".agents" / "skills"
+
+
+def normalized_lexical_path(path):
+    return pathlib.Path(os.path.abspath(os.path.normpath(str(path))))
+
+
+def paths_overlap(left, right):
+    left = pathlib.Path(left)
+    right = pathlib.Path(right)
+    for normalized_left, normalized_right in (
+        (normalized_lexical_path(left), normalized_lexical_path(right)),
+        (left.resolve(strict=False), right.resolve(strict=False)),
+    ):
+        if (
+            normalized_left == normalized_right
+            or normalized_left in normalized_right.parents
+            or normalized_right in normalized_left.parents
+        ):
+            return True
+    return False
+
+
+def shared_skill_mutation_path(path):
+    path = pathlib.Path(path)
+    shared_root = shared_skills_path()
+    shared_parent = shared_root.parent
+    if not path.is_absolute() or path.name in ("", ".", ".."):
+        raise ValueError("Shared Skill path must identify a leaf below ~/.agents/skills")
+    if shared_parent.is_symlink() or shared_root.is_symlink():
+        raise ValueError("Refusing to mutate a shared Skill through a symbolic-link parent")
+    if FIXED_CENTER_PATH.is_symlink() or paths_overlap(FIXED_CENTER_PATH, shared_root):
+        raise ValueError("Refusing to mutate a shared Skill through an unsafe center root")
+    normalized_root = shared_root.resolve(strict=False)
+    normalized_path = path.parent.resolve(strict=False) / path.name
+    if normalized_path == normalized_root:
+        raise ValueError("Shared Skill path must identify a leaf below ~/.agents/skills")
+    if normalized_root not in normalized_path.parents:
+        raise ValueError("Shared Skill path is outside the trusted ~/.agents/skills root")
+    return path
+
+
+def center_symlink_depends_on(path, dependency):
+    path = normalized_lexical_path(path)
+    dependency = normalized_lexical_path(dependency)
+    current = path
+    visited = set()
+    while current.is_symlink():
+        key = str(current)
+        if key in visited:
+            break
+        visited.add(key)
+        target = pathlib.Path(getattr(os, "readlink")(str(current)))
+        if not target.is_absolute():
+            target = current.parent / target
+        target = normalized_lexical_path(target)
+        if target == dependency or dependency in target.parents:
+            return True
+        current = target
+    try:
+        return path.resolve(strict=True) == dependency.resolve(strict=True)
+    except (FileNotFoundError, OSError, RuntimeError):
+        return False
+
+
+def center_symlink_dependents(source):
+    center = center_path()
+    try:
+        entries = list(center.iterdir())
+    except (FileNotFoundError, PermissionError) as error:
+        raise ValueError("The center library cannot be inspected safely") from error
+    return sorted(
+        (
+            entry for entry in entries
+            if entry.is_symlink() and center_symlink_depends_on(entry, source)
+        ),
+        key=lambda entry: entry.name.lower(),
+    )
+
+
+def detach_center_symlink_dependents(source):
+    source = pathlib.Path(source)
+    dependents = center_symlink_dependents(source)
+    if not dependents:
+        return
+    source_hash = verified_skill_hash(source, "Shared Skill")
+    expected_dependents = []
+    for dependent in dependents:
+        if (
+            not dependent.is_symlink()
+            or not center_symlink_depends_on(dependent, source)
+        ):
+            raise ValueError("A dependent center Skill changed before it was detached")
+        expected_dependents.append((
+            dependent,
+            verified_skill_hash(dependent, "Dependent center Skill"),
+        ))
+    for dependent, expected_hash in expected_dependents:
+        if (
+            not dependent.is_symlink()
+            or verified_skill_hash(dependent, "Dependent center Skill") != expected_hash
+            or verified_skill_hash(source, "Shared Skill") != source_hash
+        ):
+            raise ValueError("A dependent center Skill changed before it was detached")
+        atomic_replace_skill_directory(dependent, dependent)
+        if (
+            dependent.is_symlink()
+            or verified_skill_hash(dependent, "Detached center Skill") != expected_hash
+        ):
+            raise ValueError("A detached center Skill failed final verification")
+    if (
+        verified_skill_hash(source, "Shared Skill") != source_hash
+        or center_symlink_dependents(source)
+    ):
+        raise ValueError("Not all dependent center Skills could be detached")
+
+
+def prepare_shared_target_write(path, center_source, replace_center=False):
+    path = shared_skill_mutation_path(path)
+    detach_center_symlink_dependents(path)
+    if replace_center:
+        detach_center_symlink_dependents(center_source)
+    path = shared_skill_mutation_path(path)
+    if paths_overlap(center_source, path):
+        raise ValueError("Center and shared Skill paths overlap after safe detachment")
+    return path
+
+
+def remove_shared_skill_path(path):
+    path = shared_skill_mutation_path(path)
+    detach_center_symlink_dependents(path)
+    path = shared_skill_mutation_path(path)
+    if center_symlink_dependents(path):
+        raise ValueError("Dependent center Skill links still reference the shared source")
+    remove_path(path)
+
+
 def copy_or_link(source, target, mode):
     target.parent.mkdir(parents=True, exist_ok=True)
     if mode == "link":
@@ -689,7 +961,84 @@ def inventory():
             "unmanagedSkillCount": unmanaged_count,
             "readOnlySkillCount": 0,
         })
+    shared_root = shared_skills_path()
+    for path in skill_directories(shared_root):
+        skill_id = path.name
+        if skill_id in skills:
+            actual_mode = "link" if path.is_symlink() else "copy"
+            source_hash = skills[skill_id]["currentHash"]
+            current_hash = hash_dir(path.resolve() if path.is_symlink() else path)
+            status = "ok" if source_hash == current_hash else "copyDiverged"
+            skills[skill_id]["installedAgents"].append({
+                "agentId": SHARED_SKILLS_AGENT_ID,
+                "displayName": ".agents",
+                "iconKey": SHARED_SKILLS_AGENT_ID,
+                "mode": actual_mode,
+                "status": status,
+            })
+            target = {
+                "id": SHARED_SKILLS_AGENT_ID + "::" + skill_id,
+                "skillId": skill_id,
+                "agentId": SHARED_SKILLS_AGENT_ID,
+                "targetPath": str(path),
+                "resolvedTargetPath": str(path.resolve(strict=False)),
+                "installMode": actual_mode,
+                "actualMode": actual_mode,
+                "sourceHash": source_hash,
+                "currentHash": current_hash,
+                "status": status,
+                "createdAt": now(),
+                "updatedAt": now(),
+                "claims": pack_claims(SHARED_SKILLS_AGENT_ID, skill_id),
+            }
+            targets[target["id"]] = target
+        else:
+            unmanaged_id = SHARED_SKILLS_AGENT_ID + "::" + skill_id
+            unmanaged.append({
+                "id": unmanaged_id,
+                "itemType": "skill",
+                "agentId": SHARED_SKILLS_AGENT_ID,
+                "path": str(path),
+                "inferredSkillId": skill_id,
+                "hash": hash_dir(path),
+                "reason": "shared_agents_directory",
+                "readOnly": False,
+            })
     return skills, agents, unmanaged, targets
+
+
+def shared_skill_projection(agent_id, unmanaged, targets):
+    if agent_id not in SHARED_SKILL_CONSUMERS:
+        return [], []
+    managed_by_path = {}
+    for target in sorted(
+        (item for item in targets.values()
+         if item["agentId"] == SHARED_SKILLS_AGENT_ID),
+        key=lambda item: (item["targetPath"], item["id"]),
+    ):
+        path = str(pathlib.Path(target["targetPath"]).resolve(strict=False))
+        managed_by_path.setdefault(path, target)
+    unmanaged_by_path = {}
+    for item in sorted(
+        (item for item in unmanaged
+         if item["agentId"] == SHARED_SKILLS_AGENT_ID),
+        key=lambda item: (item["path"], item["id"]),
+    ):
+        path = str(pathlib.Path(item["path"]).resolve(strict=False))
+        if path not in managed_by_path:
+            unmanaged_by_path.setdefault(path, item)
+    managed_skills = sorted(
+        managed_by_path.values(),
+        key=lambda item: (item["skillId"].lower(), item["targetPath"]),
+    )
+    unmanaged_skills = sorted(
+        unmanaged_by_path.values(),
+        key=lambda item: (
+            str(item.get("inferredSkillId") or pathlib.Path(item["path"]).name).lower(),
+            item["path"],
+        ),
+    )
+    return managed_skills, unmanaged_skills
 
 
 def pack_detail(pack_id, skills=None, agents=None):
@@ -1093,6 +1442,19 @@ def unmanaged_inventory():
             "importableCount": sum(1 for item in items if item["canImport"]),
             "items": sorted(items, key=lambda item: item["name"].lower()),
         })
+    shared_items = by_agent.get(SHARED_SKILLS_AGENT_ID, [])
+    result.append({
+        "agentId": SHARED_SKILLS_AGENT_ID,
+        "displayName": ".agents",
+        "iconKey": SHARED_SKILLS_AGENT_ID,
+        "skillsDir": str(shared_skills_path()),
+        "installed": shared_skills_path().is_dir(),
+        "managedCount": sum(1 for item in shared_items if item["managed"]),
+        "unmanagedCount": sum(1 for item in shared_items if not item["managed"]),
+        "readOnlyCount": sum(1 for item in shared_items if item.get("readOnly")),
+        "importableCount": sum(1 for item in shared_items if item["canImport"]),
+        "items": sorted(shared_items, key=lambda item: item["name"].lower()),
+    })
     return result
 
 
@@ -1104,22 +1466,66 @@ def find_unmanaged(unmanaged_id):
     return item
 
 
+def remove_unmanaged_item(item, requested_agent_id):
+    owner = item.get("agentId")
+    if owner != requested_agent_id:
+        raise ValueError("Unmanaged Skill does not belong to this Agent")
+    if owner == SHARED_SKILLS_AGENT_ID:
+        remove_shared_skill_path(item["path"])
+        return
+    remove_path(pathlib.Path(item["path"]))
+
+
+def remove_target_distribution(target):
+    if target.get("agentId") == SHARED_SKILLS_AGENT_ID:
+        remove_shared_skill_path(target["targetPath"])
+        return
+    remove_path(pathlib.Path(target["targetPath"]))
+
+
 def adopt_preview(agent_id, unmanaged_id):
     item = find_unmanaged(unmanaged_id)
     if item["agentId"] != agent_id:
         raise ValueError("Unmanaged Skill does not belong to this Agent")
+    if agent_id == SHARED_SKILLS_AGENT_ID:
+        shared_skill_mutation_path(item["path"])
     skill_id = safe_id(item["inferredSkillId"])
     target = center_path() / skill_id
-    same_id = target.exists()
-    return {
-        "agentId": agent_id,
-        "unmanagedId": unmanaged_id,
-        "skillPath": item["path"],
-        "inferredSkillId": skill_id,
-        "hash": item["hash"],
-        "centerHasSameId": same_id,
-        "canQuickAdopt": not same_id,
-        "options": [
+    same_id = target.exists() or target.is_symlink()
+    if agent_id == SHARED_SKILLS_AGENT_ID:
+        if not same_id:
+            options = [{
+                "value": "import_cleanup",
+                "label": "Import to center and remove the shared .agents copy",
+                "destructive": True,
+            }]
+        else:
+            options = []
+            if independent_center_skill_hash(target):
+                options.append({
+                    "value": "center_over_agent",
+                    "label": "Use center skill and remove the shared .agents copy",
+                    "destructive": True,
+                })
+            options.extend([
+                {
+                    "value": "overwrite_center",
+                    "label": "Overwrite center skill and remove the shared .agents copy",
+                    "destructive": True,
+                },
+                {
+                    "value": "rename",
+                    "label": "Import under a new id and remove the shared .agents copy",
+                    "destructive": True,
+                },
+                {
+                    "value": "skip",
+                    "label": "Keep as unmanaged",
+                    "destructive": False,
+                },
+            ])
+    else:
+        options = [
             {
                 "value": "import_link",
                 "label": "导入中心库并链接",
@@ -1150,17 +1556,62 @@ def adopt_preview(agent_id, unmanaged_id):
                 "label": "跳过",
                 "destructive": False,
             },
-        ],
+        ]
+    return {
+        "agentId": agent_id,
+        "unmanagedId": unmanaged_id,
+        "skillPath": item["path"],
+        "inferredSkillId": skill_id,
+        "hash": item["hash"],
+        "centerHasSameId": same_id,
+        "canQuickAdopt": not same_id,
+        "options": options,
     }
 
 
 def execute_adopt(agent_id, unmanaged_id, option, renamed_id=None):
     preview = adopt_preview(agent_id, unmanaged_id)
+    if agent_id == SHARED_SKILLS_AGENT_ID:
+        allowed_options = [item["value"] for item in preview["options"]]
+        if option not in allowed_options:
+            raise ValueError("Adopt option is not allowed for a shared .agents Skill")
     if option == "skip":
         return ""
     source = pathlib.Path(preview["skillPath"])
+    if agent_id == SHARED_SKILLS_AGENT_ID:
+        source = shared_skill_mutation_path(source)
     skill_id = safe_id(renamed_id if option == "rename" else preview["inferredSkillId"])
     target = center_path() / skill_id
+    if agent_id == SHARED_SKILLS_AGENT_ID:
+        detach_center_symlink_dependents(source)
+        source = shared_skill_mutation_path(source)
+        target_present = target.exists() or target.is_symlink()
+        if target_present and option == "center_over_agent":
+            if not independent_center_skill_hash(target):
+                raise ValueError("Center Skill is not an independent readable Skill directory")
+            remove_shared_skill_path(source)
+            return skill_id
+        if target_present and option == "overwrite_center":
+            detach_center_symlink_dependents(target)
+        elif target_present:
+            raise ValueError("Center Skill already exists: " + skill_id)
+        atomic_replace_skill_directory(
+            source,
+            target,
+            after_replace=lambda: remove_shared_skill_path(source),
+        )
+        STATE["sources"][skill_id] = {
+            "sourceType": "agent_import",
+            "sourceUri": None,
+            "sourceRef": None,
+            "importedFromAgent": agent_id,
+            "importedFromPath": str(source),
+            "installedVia": "remote_adopt",
+            "createdAt": now(),
+            "updatedAt": now(),
+        }
+        save_state()
+        return skill_id
     if target.exists() and option == "center_over_agent":
         remove_path(source)
         copy_or_link(target, source, STATE["settings"]["defaultDistributeMode"])
@@ -1408,8 +1859,13 @@ def agent_detail(agent_id):
     spec = agent_spec(agent_id)
     if not spec:
         raise ValueError("Unknown Agent: " + agent_id)
-    skills, agents, _, targets = inventory()
+    skills, agents, unmanaged, targets = inventory()
     agent = next(item for item in agents if item["id"] == agent_id)
+    inherited_managed, inherited_unmanaged = shared_skill_projection(
+        agent_id,
+        unmanaged,
+        targets,
+    )
     applied = []
     for pack_id in applied_pack_ids(agent_id):
         detail = pack_detail(pack_id, skills, agents)
@@ -1426,6 +1882,9 @@ def agent_detail(agent_id):
         "pluginDir": str(agent_plugin_path(agent_id)),
         "agentDir": str(agent_skills_path(agent_id).parent),
         "skills": [item for item in targets.values() if item["agentId"] == agent_id],
+        "inheritsSharedSkills": agent_id in SHARED_SKILL_CONSUMERS,
+        "inheritedManagedSkills": inherited_managed,
+        "inheritedUnmanagedSkills": inherited_unmanaged,
         "appliedPacks": applied,
         "availablePacks": overview()["packs"],
         "mcpServers": [],
@@ -2469,7 +2928,7 @@ def dispatch():
             if remove_linked:
                 for target in targets.values():
                     if target["skillId"] == skill_id:
-                        remove_path(pathlib.Path(target["targetPath"]))
+                        remove_target_distribution(target)
             remove_path(center_path() / skill_id)
             STATE["sources"].pop(skill_id, None)
             for pack in STATE["packs"].values():
@@ -2543,6 +3002,7 @@ def dispatch():
                 })
         return {"items": results, "finalizationError": None}
     if command in ("delete_unmanaged_agent_skill", "delete_unmanaged_agent_skills"):
+        requested_agent_id = args.get("agentId")
         ids = (
             [args["unmanagedId"]]
             if command == "delete_unmanaged_agent_skill"
@@ -2553,7 +3013,7 @@ def dispatch():
         for unmanaged_id in ids:
             try:
                 item = find_unmanaged(unmanaged_id)
-                remove_path(pathlib.Path(item["path"]))
+                remove_unmanaged_item(item, requested_agent_id)
                 deleted += 1
             except Exception as error:
                 failures.append({"unmanagedId": unmanaged_id, "error": str(error)})
@@ -2576,11 +3036,23 @@ def dispatch():
             source = pathlib.Path(skill["centerPath"])
             destination = pathlib.Path(target["targetPath"])
             if action == "agent_over_center":
-                remove_path(source)
-                shutil.copytree(destination, source, symlinks=True)
+                if target["agentId"] == SHARED_SKILLS_AGENT_ID:
+                    destination = prepare_shared_target_write(
+                        destination,
+                        source,
+                        replace_center=True,
+                    )
+                    atomic_replace_skill_directory(destination, source)
+                else:
+                    remove_path(source)
+                    shutil.copytree(destination, source, symlinks=True)
             elif action == "center_over_agent":
-                remove_path(destination)
-                shutil.copytree(source, destination, symlinks=True)
+                if target["agentId"] == SHARED_SKILLS_AGENT_ID:
+                    destination = prepare_shared_target_write(destination, source)
+                    atomic_replace_skill_directory(source, destination)
+                else:
+                    remove_path(destination)
+                    shutil.copytree(source, destination, symlinks=True)
             skills, _, _, targets = inventory()
             target = targets[target_id]
             skill = skills[target["skillId"]]
@@ -2625,8 +3097,11 @@ def dispatch():
             if not target:
                 failures.append({"targetId": target_id, "error": "Target not found"})
                 continue
-            remove_path(pathlib.Path(target["targetPath"]))
-            deleted += 1
+            try:
+                remove_target_distribution(target)
+                deleted += 1
+            except Exception as error:
+                failures.append({"targetId": target_id, "error": str(error)})
         if command == "delete_skill_target_distribution":
             if failures:
                 raise ValueError(failures[0]["error"])
@@ -2962,8 +3437,12 @@ def dispatch():
                 raise ValueError("Target not found")
             source = pathlib.Path(skills[target["skillId"]]["centerPath"])
             destination = pathlib.Path(target["targetPath"])
-            remove_path(destination)
-            shutil.copytree(source, destination, symlinks=True)
+            if target["agentId"] == SHARED_SKILLS_AGENT_ID:
+                destination = prepare_shared_target_write(destination, source)
+                atomic_replace_skill_directory(source, destination)
+            else:
+                remove_path(destination)
+                shutil.copytree(source, destination, symlinks=True)
         return None
     if command == "execute_safe_fixes":
         return 0

--- a/src-tauri/src/remote/skill_manager.rs
+++ b/src-tauri/src/remote/skill_manager.rs
@@ -438,12 +438,669 @@ mod tests {
         std::fs::remove_dir_all(home).expect("remove test home");
     }
 
+    #[test]
+    fn remote_shared_mutations_detach_center_links_and_validate_owners() {
+        let home = std::env::temp_dir().join(format!(
+            "agentbro-remote-shared-detach-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let shared_root = home.join(".agents/skills");
+        let center = home.join(".agentbro/skills");
+        let shared = shared_root.join("same");
+        write_remote_skill(&shared, "Same", "same-v1\n");
+        std::fs::create_dir_all(&center).expect("center directory");
+        std::os::unix::fs::symlink(&shared, center.join("same")).expect("same-name center link");
+        std::os::unix::fs::symlink(&shared, center.join("alias")).expect("center alias link");
+        std::os::unix::fs::symlink(center.join("alias"), center.join("alias-chain"))
+            .expect("center alias chain");
+
+        let detail = run_script(
+            &home,
+            "get_agent_detail_v2",
+            serde_json::json!({ "agentId": "codex" }),
+        );
+        assert_eq!(detail["inheritsSharedSkills"], true);
+        assert!(detail.get("inheritedSkills").is_none());
+        let managed = detail["inheritedManagedSkills"]
+            .as_array()
+            .expect("managed shared skills");
+        assert_eq!(managed.len(), 1);
+        assert_eq!(managed[0]["id"], "agents::same");
+        assert_eq!(managed[0]["agentId"], "agents");
+        assert!(managed[0]["claims"]
+            .as_array()
+            .is_some_and(|value| !value.is_empty()));
+
+        run_script(
+            &home,
+            "delete_skill_target_distribution",
+            serde_json::json!({ "targetId": "agents::same" }),
+        );
+        assert!(!shared.exists());
+        for name in ["same", "alias", "alias-chain"] {
+            let detached = center.join(name);
+            assert!(detached.is_dir(), "{name}");
+            assert!(!detached.is_symlink(), "{name}");
+            assert_eq!(
+                std::fs::read_to_string(detached.join("SKILL.md")).expect("detached Skill"),
+                "---\nname: Same\n---\nsame-v1\n"
+            );
+        }
+
+        let adopt_source = shared_root.join("adopt-source");
+        write_remote_skill(&adopt_source, "Adopt Source", "adopt-v1\n");
+        let adopt_alias = center.join("adopt-alias");
+        std::os::unix::fs::symlink(&adopt_source, &adopt_alias).expect("adopt alias");
+        let adopted = run_script(
+            &home,
+            "execute_adopt_agent_skill",
+            serde_json::json!({
+                "agentId": "agents",
+                "unmanagedId": "agents::adopt-source",
+                "option": "import_cleanup",
+                "renamedId": null,
+            }),
+        );
+        assert_eq!(adopted, "adopt-source");
+        assert!(!adopt_source.exists());
+        assert!(center.join("adopt-source/SKILL.md").is_file());
+        assert!(adopt_alias.is_dir());
+        assert!(!adopt_alias.is_symlink());
+
+        let blocked = shared_root.join("blocked");
+        write_remote_skill(&blocked, "Blocked", "blocked-v1\n");
+        std::os::unix::fs::symlink(blocked.join("missing"), blocked.join("dangling"))
+            .expect("dangling nested link");
+        let blocked_center = center.join("blocked");
+        std::os::unix::fs::symlink(&blocked, &blocked_center).expect("blocked center link");
+        let blocked_error = run_script_error(
+            &home,
+            "delete_skill_target_distribution",
+            serde_json::json!({ "targetId": "agents::blocked" }),
+        );
+        assert!(!blocked_error.is_empty());
+        assert!(blocked.is_dir());
+        assert!(blocked_center.is_symlink());
+
+        let blocked_adopt = shared_root.join("blocked-adopt");
+        write_remote_skill(&blocked_adopt, "Blocked Adopt", "blocked-adopt-v1\n");
+        std::os::unix::fs::symlink(
+            blocked_adopt.join("missing"),
+            blocked_adopt.join("dangling"),
+        )
+        .expect("dangling adopt link");
+        let blocked_adopt_alias = center.join("blocked-adopt-alias");
+        std::os::unix::fs::symlink(&blocked_adopt, &blocked_adopt_alias)
+            .expect("blocked adopt alias");
+        let blocked_adopt_error = run_script_error(
+            &home,
+            "execute_adopt_agent_skill",
+            serde_json::json!({
+                "agentId": "agents",
+                "unmanagedId": "agents::blocked-adopt",
+                "option": "import_cleanup",
+                "renamedId": null,
+            }),
+        );
+        assert!(!blocked_adopt_error.is_empty());
+        assert!(blocked_adopt.is_dir());
+        assert!(blocked_adopt_alias.is_symlink());
+        assert!(!center.join("blocked-adopt").exists());
+        std::fs::remove_file(&blocked_adopt_alias).expect("remove blocked adopt alias");
+        std::fs::remove_dir_all(&blocked_adopt).expect("remove blocked adopt source");
+
+        let private = home.join(".claude/skills/private");
+        write_remote_skill(&private, "Private", "private-v1\n");
+        let owner_error = run_script_error(
+            &home,
+            "delete_unmanaged_agent_skill",
+            serde_json::json!({
+                "agentId": "codex",
+                "unmanagedId": "claude-code::private",
+            }),
+        );
+        assert!(owner_error.contains("does not belong to this Agent"));
+        assert!(private.is_dir());
+
+        let inventory_only = shared_root.join("inventory-only");
+        write_remote_skill(&inventory_only, "Inventory Only", "inventory-v1\n");
+        let shared_owner_error = run_script_error(
+            &home,
+            "delete_unmanaged_agent_skill",
+            serde_json::json!({
+                "agentId": "codex",
+                "unmanagedId": "agents::inventory-only",
+            }),
+        );
+        assert!(shared_owner_error.contains("does not belong to this Agent"));
+        assert!(inventory_only.is_dir());
+
+        let inventory = run_script(
+            &home,
+            "list_agent_skill_inventory_v2",
+            serde_json::json!({}),
+        );
+        let virtual_owner = inventory
+            .as_array()
+            .expect("Agent inventory")
+            .iter()
+            .find(|agent| agent["agentId"] == "agents")
+            .expect("virtual shared owner");
+        assert_eq!(virtual_owner["unmanagedCount"], 1);
+        let inventory_item = virtual_owner["items"]
+            .as_array()
+            .expect("virtual owner items")
+            .iter()
+            .find(|item| item["id"] == "agents::inventory-only")
+            .expect("shared unmanaged item");
+        assert_eq!(inventory_item["reason"], "shared_agents_directory");
+
+        let overview = run_script(&home, "skill_manager_overview", serde_json::json!({}));
+        let visible = overview["agents"].as_array().expect("visible Agents");
+        assert!(!visible.iter().any(|agent| agent["id"] == "agents"));
+        assert!(!visible.iter().any(|agent| agent["id"] == "zcode"));
+
+        std::fs::remove_dir_all(home).expect("remove test home");
+    }
+
+    #[test]
+    fn remote_shared_writes_reject_symlinked_roots() {
+        let home = std::env::temp_dir().join(format!(
+            "agentbro-remote-shared-write-guard-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let center = home.join(".agentbro/skills/demo");
+        write_remote_skill(&center, "Demo", "center-v1\n");
+        let external_root = home.join("external-shared");
+        let external = external_root.join("demo");
+        write_remote_skill(&external, "Demo", "shared-v1\n");
+        std::fs::create_dir_all(home.join(".agents")).expect("shared parent");
+        std::os::unix::fs::symlink(&external_root, home.join(".agents/skills"))
+            .expect("shared root link");
+
+        for (command, args) in [
+            (
+                "execute_sync_copy_target",
+                serde_json::json!({
+                    "targetId": "agents::demo",
+                    "action": "center_over_agent",
+                }),
+            ),
+            (
+                "execute_sync_copy_target",
+                serde_json::json!({
+                    "targetId": "agents::demo",
+                    "action": "agent_over_center",
+                }),
+            ),
+            (
+                "execute_fix_diagnosis_issue",
+                serde_json::json!({
+                    "issueType": "copy_diverged",
+                    "entityId": "agents::demo",
+                }),
+            ),
+        ] {
+            let error = run_script_error(&home, command, args);
+            assert!(error.contains("symbolic-link parent"), "{error}");
+            assert_eq!(
+                std::fs::read_to_string(external.join("SKILL.md")).expect("shared Skill"),
+                "---\nname: Demo\n---\nshared-v1\n"
+            );
+            assert_eq!(
+                std::fs::read_to_string(center.join("SKILL.md")).expect("center Skill"),
+                "---\nname: Demo\n---\ncenter-v1\n"
+            );
+        }
+
+        std::fs::remove_dir_all(home).expect("remove test home");
+
+        let overlap_home = std::env::temp_dir().join(format!(
+            "agentbro-remote-shared-overlap-guard-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let overlap_shared = overlap_home.join(".agents/skills/demo");
+        write_remote_skill(&overlap_shared, "Demo", "shared-v1\n");
+        std::fs::create_dir_all(overlap_home.join(".agentbro")).expect("center parent");
+        std::os::unix::fs::symlink(
+            overlap_home.join(".agents/skills"),
+            overlap_home.join(".agentbro/skills"),
+        )
+        .expect("overlapping center root");
+        let overlap_error = run_script_error(
+            &overlap_home,
+            "delete_skill_target_distribution",
+            serde_json::json!({ "targetId": "agents::demo" }),
+        );
+        assert!(overlap_error.contains("unsafe center root"));
+        assert!(overlap_shared.is_dir());
+        std::fs::remove_dir_all(overlap_home).expect("remove overlap test home");
+    }
+
+    #[test]
+    fn remote_shared_center_over_agent_requires_an_independent_center_skill() {
+        let home = std::env::temp_dir().join(format!(
+            "agentbro-remote-shared-invalid-center-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let shared_root = home.join(".agents/skills");
+        let center = home.join(".agentbro/skills");
+        std::fs::create_dir_all(&center).expect("center directory");
+
+        let invalid_directory = center.join("invalid-directory");
+        std::fs::create_dir_all(&invalid_directory).expect("invalid center directory");
+        std::fs::write(invalid_directory.join("sentinel"), "keep-directory\n")
+            .expect("invalid center sentinel");
+        let regular_file = center.join("regular-file");
+        std::fs::write(&regular_file, "keep-file\n").expect("invalid center file");
+        let dangling_link = center.join("dangling-link");
+        std::os::unix::fs::symlink(center.join("missing"), &dangling_link)
+            .expect("dangling center link");
+
+        for skill_id in ["invalid-directory", "regular-file", "dangling-link"] {
+            let shared = shared_root.join(skill_id);
+            write_remote_skill(&shared, skill_id, "shared-v1\n");
+            let preview = run_script(
+                &home,
+                "preview_adopt_agent_skill",
+                serde_json::json!({
+                    "agentId": "agents",
+                    "unmanagedId": format!("agents::{skill_id}"),
+                }),
+            );
+            assert!(preview["options"]
+                .as_array()
+                .expect("adoption options")
+                .iter()
+                .all(|option| option["value"] != "center_over_agent"));
+            let error = run_script_error(
+                &home,
+                "execute_adopt_agent_skill",
+                serde_json::json!({
+                    "agentId": "agents",
+                    "unmanagedId": format!("agents::{skill_id}"),
+                    "option": "center_over_agent",
+                    "renamedId": null,
+                }),
+            );
+            assert!(error.contains("not allowed"), "{error}");
+            assert_eq!(
+                std::fs::read_to_string(shared.join("SKILL.md")).expect("shared Skill"),
+                format!("---\nname: {skill_id}\n---\nshared-v1\n")
+            );
+        }
+
+        assert_eq!(
+            std::fs::read_to_string(invalid_directory.join("sentinel"))
+                .expect("invalid directory preserved"),
+            "keep-directory\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&regular_file).expect("regular file preserved"),
+            "keep-file\n"
+        );
+        assert!(dangling_link.is_symlink());
+        assert_eq!(
+            std::fs::read_link(&dangling_link).expect("dangling target"),
+            center.join("missing")
+        );
+
+        std::fs::remove_dir_all(home).expect("remove test home");
+    }
+
+    #[test]
+    fn remote_shared_copy_replacements_restore_destinations_on_faults() {
+        const FAIL_ACTIVATION: &str = r#"
+_agentbro_original_replace = os.replace
+def _agentbro_fail_activation(source, destination):
+    if pathlib.Path(source).name == "staged" and ".shared-skill-replace-" in str(source):
+        raise OSError("injected activation failure")
+    return _agentbro_original_replace(source, destination)
+os.replace = _agentbro_fail_activation
+"#;
+        const FAIL_STAGING_COPY: &str = r#"
+_agentbro_original_copytree = shutil.copytree
+def _agentbro_fail_staging_copy(source, destination, *args, **kwargs):
+    if pathlib.Path(destination).name == "staged" and ".shared-skill-replace-" in str(destination):
+        pathlib.Path(destination).mkdir(parents=True, exist_ok=True)
+        (pathlib.Path(destination) / "partial").write_text("partial")
+        raise OSError("injected staging copy failure")
+    return _agentbro_original_copytree(source, destination, *args, **kwargs)
+shutil.copytree = _agentbro_fail_staging_copy
+"#;
+
+        let home = std::env::temp_dir().join(format!(
+            "agentbro-remote-shared-atomic-copy-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let shared_root = home.join(".agents/skills");
+        let center_root = home.join(".agentbro/skills");
+
+        let adopt_source = shared_root.join("adopt");
+        let adopt_destination = center_root.join("adopt");
+        write_remote_skill(&adopt_source, "Adopt", "shared-adopt-v1\n");
+        std::fs::create_dir_all(&adopt_destination).expect("invalid adopt destination");
+        std::fs::write(adopt_destination.join("sentinel"), "old-adopt\n").expect("adopt sentinel");
+        let adopt_error = run_script_error_with_prelude(
+            &home,
+            "execute_adopt_agent_skill",
+            serde_json::json!({
+                "agentId": "agents",
+                "unmanagedId": "agents::adopt",
+                "option": "overwrite_center",
+                "renamedId": null,
+            }),
+            FAIL_ACTIVATION,
+        );
+        assert!(
+            adopt_error.contains("injected activation failure"),
+            "{adopt_error}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(adopt_destination.join("sentinel"))
+                .expect("old adopt destination"),
+            "old-adopt\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(adopt_source.join("SKILL.md")).expect("adopt source"),
+            "---\nname: Adopt\n---\nshared-adopt-v1\n"
+        );
+
+        let upload_center = center_root.join("upload");
+        let upload_shared = shared_root.join("upload");
+        write_remote_skill(&upload_center, "Upload", "old-center-v1\n");
+        write_remote_skill(&upload_shared, "Upload", "shared-v2\n");
+        let upload_error = run_script_error_with_prelude(
+            &home,
+            "execute_sync_copy_target",
+            serde_json::json!({
+                "targetId": "agents::upload",
+                "action": "agent_over_center",
+            }),
+            FAIL_ACTIVATION,
+        );
+        assert!(
+            upload_error.contains("injected activation failure"),
+            "{upload_error}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(upload_center.join("SKILL.md")).expect("old center"),
+            "---\nname: Upload\n---\nold-center-v1\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(upload_shared.join("SKILL.md")).expect("upload source"),
+            "---\nname: Upload\n---\nshared-v2\n"
+        );
+
+        let download_center = center_root.join("download");
+        let download_shared = shared_root.join("download");
+        write_remote_skill(&download_center, "Download", "center-v2\n");
+        write_remote_skill(&download_shared, "Download", "old-shared-v1\n");
+        let download_error = run_script_error_with_prelude(
+            &home,
+            "execute_sync_copy_target",
+            serde_json::json!({
+                "targetId": "agents::download",
+                "action": "center_over_agent",
+            }),
+            FAIL_ACTIVATION,
+        );
+        assert!(
+            download_error.contains("injected activation failure"),
+            "{download_error}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(download_shared.join("SKILL.md"))
+                .expect("old shared destination"),
+            "---\nname: Download\n---\nold-shared-v1\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(download_center.join("SKILL.md")).expect("download source"),
+            "---\nname: Download\n---\ncenter-v2\n"
+        );
+
+        let diagnosis_center = center_root.join("diagnosis");
+        let diagnosis_shared = shared_root.join("diagnosis");
+        write_remote_skill(&diagnosis_center, "Diagnosis", "center-v2\n");
+        write_remote_skill(&diagnosis_shared, "Diagnosis", "old-shared-v1\n");
+        let diagnosis_error = run_script_error_with_prelude(
+            &home,
+            "execute_fix_diagnosis_issue",
+            serde_json::json!({
+                "issueType": "copy_diverged",
+                "entityId": "agents::diagnosis",
+            }),
+            FAIL_ACTIVATION,
+        );
+        assert!(
+            diagnosis_error.contains("injected activation failure"),
+            "{diagnosis_error}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(diagnosis_shared.join("SKILL.md"))
+                .expect("old diagnosis destination"),
+            "---\nname: Diagnosis\n---\nold-shared-v1\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(diagnosis_center.join("SKILL.md")).expect("diagnosis source"),
+            "---\nname: Diagnosis\n---\ncenter-v2\n"
+        );
+
+        for (command, args) in [
+            (
+                "execute_adopt_agent_skill",
+                serde_json::json!({
+                    "agentId": "agents",
+                    "unmanagedId": "agents::adopt",
+                    "option": "overwrite_center",
+                    "renamedId": null,
+                }),
+            ),
+            (
+                "execute_sync_copy_target",
+                serde_json::json!({
+                    "targetId": "agents::upload",
+                    "action": "agent_over_center",
+                }),
+            ),
+            (
+                "execute_sync_copy_target",
+                serde_json::json!({
+                    "targetId": "agents::download",
+                    "action": "center_over_agent",
+                }),
+            ),
+            (
+                "execute_fix_diagnosis_issue",
+                serde_json::json!({
+                    "issueType": "copy_diverged",
+                    "entityId": "agents::diagnosis",
+                }),
+            ),
+        ] {
+            let copy_error = run_script_error_with_prelude(&home, command, args, FAIL_STAGING_COPY);
+            assert!(
+                copy_error.contains("injected staging copy failure"),
+                "{command}: {copy_error}"
+            );
+        }
+        assert_eq!(
+            std::fs::read_to_string(adopt_destination.join("sentinel"))
+                .expect("copy-fault adopt destination"),
+            "old-adopt\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(adopt_source.join("SKILL.md"))
+                .expect("copy-fault adopt source"),
+            "---\nname: Adopt\n---\nshared-adopt-v1\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(upload_center.join("SKILL.md"))
+                .expect("copy-fault upload destination"),
+            "---\nname: Upload\n---\nold-center-v1\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(upload_shared.join("SKILL.md"))
+                .expect("copy-fault upload source"),
+            "---\nname: Upload\n---\nshared-v2\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(download_shared.join("SKILL.md"))
+                .expect("copy-fault download destination"),
+            "---\nname: Download\n---\nold-shared-v1\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(download_center.join("SKILL.md"))
+                .expect("copy-fault download source"),
+            "---\nname: Download\n---\ncenter-v2\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(diagnosis_shared.join("SKILL.md"))
+                .expect("copy-fault diagnosis destination"),
+            "---\nname: Diagnosis\n---\nold-shared-v1\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(diagnosis_center.join("SKILL.md"))
+                .expect("copy-fault diagnosis source"),
+            "---\nname: Diagnosis\n---\ncenter-v2\n"
+        );
+        assert!(recovery_artifacts(&center_root).is_empty());
+        assert!(recovery_artifacts(&shared_root).is_empty());
+
+        std::fs::remove_dir_all(home).expect("remove test home");
+    }
+
+    #[test]
+    fn remote_shared_alias_rollback_failure_retains_recovery_artifacts() {
+        const FAIL_ACTIVATION_AND_ROLLBACK: &str = r#"
+_agentbro_original_replace = os.replace
+def _agentbro_fail_activation_and_rollback(source, destination):
+    source_name = pathlib.Path(source).name
+    if source_name in ("staged", "backup") and ".shared-skill-replace-" in str(source):
+        raise OSError("injected alias replace failure")
+    return _agentbro_original_replace(source, destination)
+os.replace = _agentbro_fail_activation_and_rollback
+"#;
+
+        let home = std::env::temp_dir().join(format!(
+            "agentbro-remote-shared-alias-recovery-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let source = home.join(".agents/skills/source");
+        let center = home.join(".agentbro/skills");
+        let alias = center.join("alias");
+        write_remote_skill(&source, "Source", "shared-v1\n");
+        std::fs::create_dir_all(&center).expect("center directory");
+        std::os::unix::fs::symlink(&source, &alias).expect("center alias");
+
+        let error = run_script_error_with_prelude(
+            &home,
+            "delete_unmanaged_agent_skill",
+            serde_json::json!({
+                "agentId": "agents",
+                "unmanagedId": "agents::source",
+            }),
+            FAIL_ACTIVATION_AND_ROLLBACK,
+        );
+        assert!(error.contains("Recovery artifacts retained at"), "{error}");
+        assert_eq!(
+            std::fs::read_to_string(source.join("SKILL.md")).expect("shared source"),
+            "---\nname: Source\n---\nshared-v1\n"
+        );
+        assert!(!alias.exists());
+        assert!(!alias.is_symlink());
+        let recoveries = recovery_artifacts(&center);
+        assert_eq!(recoveries.len(), 1);
+        let recovery = &recoveries[0];
+        assert!(recovery.join("backup").is_symlink());
+        assert_eq!(
+            std::fs::read_to_string(recovery.join("staged/SKILL.md"))
+                .expect("staged independent copy"),
+            "---\nname: Source\n---\nshared-v1\n"
+        );
+
+        std::fs::remove_dir_all(home).expect("remove test home");
+    }
+
+    fn write_remote_skill(path: &Path, name: &str, body: &str) {
+        std::fs::create_dir_all(path).expect("Skill directory");
+        std::fs::write(
+            path.join("SKILL.md"),
+            format!("---\nname: {name}\n---\n{body}"),
+        )
+        .expect("Skill markdown");
+    }
+
     fn run_script(home: &Path, command: &str, args: Value) -> Value {
         let script = render_script(command, args).expect("render remote script");
         run_rendered_script(home, &script)
     }
 
+    fn run_script_error(home: &Path, command: &str, args: Value) -> String {
+        let script = render_script(command, args).expect("render remote script");
+        let output = execute_rendered_script(home, &script);
+        assert!(
+            !output.status.success(),
+            "remote script unexpectedly succeeded: {}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+        String::from_utf8_lossy(&output.stderr).into_owned()
+    }
+
+    fn run_script_error_with_prelude(
+        home: &Path,
+        command: &str,
+        args: Value,
+        prelude: &str,
+    ) -> String {
+        let script = render_script(command, args)
+            .expect("render remote script")
+            .replace(
+                "\ntry:\n    RESPONSE = json_safe(dispatch())",
+                &format!("\n{prelude}\ntry:\n    RESPONSE = json_safe(dispatch())"),
+            );
+        let output = execute_rendered_script(home, &script);
+        assert!(
+            !output.status.success(),
+            "remote script unexpectedly succeeded: {}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+        String::from_utf8_lossy(&output.stderr).into_owned()
+    }
+
+    fn recovery_artifacts(root: &Path) -> Vec<std::path::PathBuf> {
+        if !root.is_dir() {
+            return Vec::new();
+        }
+        std::fs::read_dir(root)
+            .expect("recovery parent")
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.path())
+            .filter(|path| {
+                path.file_name().is_some_and(|name| {
+                    name.to_string_lossy().starts_with(".shared-skill-replace-")
+                })
+            })
+            .collect()
+    }
+
     fn run_rendered_script(home: &Path, script: &str) -> Value {
+        let output = execute_rendered_script(home, script);
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let payload = stdout
+            .lines()
+            .rev()
+            .find_map(|line| line.strip_prefix(RESPONSE_MARKER))
+            .expect("marked response");
+        serde_json::from_str(payload).expect("response JSON")
+    }
+
+    fn execute_rendered_script(home: &Path, script: &str) -> std::process::Output {
         let mut child = Command::new("python3")
             .arg("-")
             .stdin(Stdio::piped())
@@ -459,18 +1116,6 @@ mod tests {
             .expect("remote script stdin")
             .write_all(script.as_bytes())
             .expect("write remote script");
-        let output = child.wait_with_output().expect("run remote script");
-        assert!(
-            output.status.success(),
-            "{}",
-            String::from_utf8_lossy(&output.stderr)
-        );
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let payload = stdout
-            .lines()
-            .rev()
-            .find_map(|line| line.strip_prefix(RESPONSE_MARKER))
-            .expect("marked response");
-        serde_json::from_str(payload).expect("response JSON")
+        child.wait_with_output().expect("run remote script")
     }
 }

--- a/src-tauri/src/skills/v2/models.rs
+++ b/src-tauri/src/skills/v2/models.rs
@@ -276,24 +276,13 @@ pub struct AgentDetail {
     pub agent_dir: Option<String>,
     pub skills: Vec<SkillTargetDetail>,
     pub inherits_shared_skills: bool,
-    pub inherited_skills: Vec<InheritedSkillDetail>,
+    pub inherited_managed_skills: Vec<SkillTargetDetail>,
+    pub inherited_unmanaged_skills: Vec<UnmanagedItemDto>,
     pub applied_packs: Vec<AppliedPackSummary>,
     pub available_packs: Vec<SkillPackSummary>,
     pub mcp_servers: Vec<McpServerStatus>,
     pub plugins: Vec<PluginStatus>,
     pub health: Vec<AgentHealthIssue>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct InheritedSkillDetail {
-    pub id: String,
-    pub skill_id: String,
-    pub path: String,
-    pub resolved_path: Option<String>,
-    pub managed: bool,
-    pub target_id: Option<String>,
-    pub unmanaged_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/skills/v2/service.rs
+++ b/src-tauri/src/skills/v2/service.rs
@@ -24,8 +24,6 @@ const DEFAULT_SKILL_PACK_NAME: &str = "全量技能包";
 const DEFAULT_SKILL_PACK_DESCRIPTION: &str =
     "中心库全部 Skills。无需维护成员，应用时按当前中心库全量分发。";
 
-type InheritedSkillRow = (String, String, String, bool, Option<String>, Option<String>);
-
 pub struct Service {
     pub db: Arc<Db>,
     pub home: PathBuf,
@@ -2494,17 +2492,29 @@ impl Service {
 
     /// Remove a target's file/link AND all its DB rows (claims cascade).
     fn remove_target_completely(&self, target_id: &str) -> Result<(), String> {
-        let target_path = self.db.with_conn(|c| {
+        let target = self.db.with_conn(|c| {
             c.query_row(
-                "SELECT target_path FROM skill_targets WHERE id = ?1",
+                "SELECT agent_id, target_path FROM skill_targets WHERE id = ?1",
                 params![target_id],
-                |r| r.get::<_, String>(0),
+                |r| Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?)),
             )
             .optional()
             .map_err(|e| e.to_string())
         })?;
-        if let Some(p) = target_path {
-            fsutil::remove_path(Path::new(&p))?;
+        if let Some((agent_id, target_path)) = target {
+            let target_path = Path::new(&target_path);
+            if agent_id == SHARED_SKILLS_AGENT_ID
+                && !shared_skill_mutation_path_allowed(
+                    &self.home.join(".agents").join("skills"),
+                    target_path,
+                )
+            {
+                return Err(format!(
+                    "Refusing to delete shared managed skill outside the trusted .agents skill root: {}",
+                    target_path.display()
+                ));
+            }
+            fsutil::remove_path(target_path)?;
         }
         self.db.with_conn(|c| {
             c.execute(
@@ -3699,8 +3709,10 @@ impl Service {
                 }),
             }
         }
-        if deleted > 0 {
+        if deleted > 0 && failures.is_empty() {
             self.scan_one_agent_into_db(agent_id)?;
+        }
+        if deleted > 0 {
             self.refresh_snapshot_best_effort();
         }
         Ok(DeleteUnmanagedAgentSkillsResult { deleted, failures })
@@ -3729,9 +3741,13 @@ impl Service {
         }
 
         let path = Path::new(&item.path);
-        let allowed = agent_meta::agent_owned_skill_dirs(&self.home, agent_id)
-            .into_iter()
-            .any(|root| unmanaged_delete_path_allowed(&root, path));
+        let allowed = if agent_id == SHARED_SKILLS_AGENT_ID {
+            shared_skill_mutation_path_allowed(&self.home.join(".agents").join("skills"), path)
+        } else {
+            agent_meta::agent_owned_skill_dirs(&self.home, agent_id)
+                .into_iter()
+                .any(|root| unmanaged_delete_path_allowed(&root, path))
+        };
         if !allowed {
             return Err(format!(
                 "Refusing to delete unmanaged skill outside '{}' skill roots: {}",
@@ -3850,7 +3866,7 @@ impl Service {
 
         let path = Path::new(&item.path);
         let allowed = if agent_id == SHARED_SKILLS_AGENT_ID {
-            shared_adopt_path_allowed(&self.home.join(".agents").join("skills"), path)
+            shared_skill_mutation_path_allowed(&self.home.join(".agents").join("skills"), path)
         } else {
             agent_meta::agent_owned_skill_dirs(&self.home, agent_id)
                 .into_iter()
@@ -5328,61 +5344,20 @@ impl Service {
                 .map(|path| path.display().to_string())
         });
 
-        let targets = self.db.with_conn(|c| {
-            let mut stmt = c
-                .prepare(
-                    "SELECT id, skill_id, target_path, install_mode, actual_mode, source_hash, current_hash, status, created_at, updated_at
-                     FROM skill_targets WHERE agent_id = ?1 ORDER BY target_path",
-                )
-                .map_err(|e| e.to_string())?;
-            let rows = stmt
-                .query_map([agent_id], |r| {
-                    Ok(TargetRow {
-                        id: r.get(0)?,
-                        skill_id: r.get(1)?,
-                        agent_id: agent_id.to_string(),
-                        target_path: r.get(2)?,
-                        install_mode: r.get(3)?,
-                        actual_mode: r.get(4)?,
-                        source_hash: r.get(5)?,
-                        current_hash: r.get(6)?,
-                        status: r.get(7)?,
-                        created_at: r.get(8)?,
-                        updated_at: r.get(9)?,
-                    })
-                })
-                .map_err(|e| e.to_string())?;
-            let mut v = Vec::new();
-            for r in rows {
-                v.push(r.map_err(|e| e.to_string())?);
-            }
-            Ok::<_, String>(v)
-        })?;
-
-        let mut skills = Vec::new();
-        for t in targets {
-            let claims = self.claims_for_target(&t.id).unwrap_or_default();
-            skills.push(SkillTargetDetail {
-                id: t.id,
-                skill_id: t.skill_id,
-                agent_id: t.agent_id,
-                resolved_target_path: resolved_target_path(&t.target_path),
-                target_path: t.target_path,
-                install_mode: t.install_mode,
-                actual_mode: t.actual_mode,
-                source_hash: t.source_hash,
-                current_hash: t.current_hash,
-                status: t.status,
-                created_at: t.created_at,
-                updated_at: t.updated_at,
-                claims,
-            });
-        }
-        let mut inherited_skills = self.inherited_skills_for_agent(agent_id)?;
-        inherited_skills.sort_by(|left, right| {
+        let skills = self.skill_targets_for_agent(agent_id)?;
+        let (mut inherited_managed_skills, mut inherited_unmanaged_skills) =
+            self.inherited_skills_for_agent(agent_id)?;
+        inherited_managed_skills.sort_by(|left, right| {
             left.skill_id
                 .to_lowercase()
                 .cmp(&right.skill_id.to_lowercase())
+                .then_with(|| left.target_path.cmp(&right.target_path))
+        });
+        inherited_unmanaged_skills.sort_by(|left, right| {
+            unmanaged_skill_name(left)
+                .to_lowercase()
+                .cmp(&unmanaged_skill_name(right).to_lowercase())
+                .then_with(|| left.path.cmp(&right.path))
         });
         let inherits_shared_skills = agent_meta::inherits_shared_agents_skills(agent_id);
 
@@ -5432,7 +5407,8 @@ impl Service {
             agent_dir,
             skills,
             inherits_shared_skills,
-            inherited_skills,
+            inherited_managed_skills,
+            inherited_unmanaged_skills,
             applied_packs,
             available_packs,
             mcp_servers,
@@ -5441,85 +5417,117 @@ impl Service {
         })
     }
 
+    fn skill_targets_for_agent(&self, agent_id: &str) -> Result<Vec<SkillTargetDetail>, String> {
+        let targets = self.db.with_conn(|c| {
+            let mut stmt = c
+                .prepare(
+                    "SELECT id, skill_id, target_path, install_mode, actual_mode, source_hash, current_hash, status, created_at, updated_at
+                     FROM skill_targets WHERE agent_id = ?1 ORDER BY target_path, id",
+                )
+                .map_err(|e| e.to_string())?;
+            let rows = stmt
+                .query_map([agent_id], |r| {
+                    Ok(TargetRow {
+                        id: r.get(0)?,
+                        skill_id: r.get(1)?,
+                        agent_id: agent_id.to_string(),
+                        target_path: r.get(2)?,
+                        install_mode: r.get(3)?,
+                        actual_mode: r.get(4)?,
+                        source_hash: r.get(5)?,
+                        current_hash: r.get(6)?,
+                        status: r.get(7)?,
+                        created_at: r.get(8)?,
+                        updated_at: r.get(9)?,
+                    })
+                })
+                .map_err(|e| e.to_string())?;
+            let mut v = Vec::new();
+            for r in rows {
+                v.push(r.map_err(|e| e.to_string())?);
+            }
+            Ok::<_, String>(v)
+        })?;
+
+        let mut skills = Vec::new();
+        for t in targets {
+            let claims = self.claims_for_target(&t.id)?;
+            skills.push(SkillTargetDetail {
+                id: t.id,
+                skill_id: t.skill_id,
+                agent_id: t.agent_id,
+                resolved_target_path: resolved_target_path(&t.target_path),
+                target_path: t.target_path,
+                install_mode: t.install_mode,
+                actual_mode: t.actual_mode,
+                source_hash: t.source_hash,
+                current_hash: t.current_hash,
+                status: t.status,
+                created_at: t.created_at,
+                updated_at: t.updated_at,
+                claims,
+            });
+        }
+        Ok(skills)
+    }
+
     fn inherited_skills_for_agent(
         &self,
         agent_id: &str,
-    ) -> Result<Vec<InheritedSkillDetail>, String> {
+    ) -> Result<(Vec<SkillTargetDetail>, Vec<UnmanagedItemDto>), String> {
         if !agent_meta::inherits_shared_agents_skills(agent_id) {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), Vec::new()));
         }
-        let rows = self.db.with_conn(|connection| {
+        let mut managed_by_path = BTreeMap::new();
+        for target in self.skill_targets_for_agent(SHARED_SKILLS_AGENT_ID)? {
+            managed_by_path
+                .entry(fsutil::normalized_path(Path::new(&target.target_path)))
+                .or_insert(target);
+        }
+        let mut unmanaged_by_path = BTreeMap::new();
+        for item in self.unmanaged_items_for_agent(SHARED_SKILLS_AGENT_ID)? {
+            let path = fsutil::normalized_path(Path::new(&item.path));
+            if !managed_by_path.contains_key(&path) {
+                unmanaged_by_path.entry(path).or_insert(item);
+            }
+        }
+        Ok((
+            managed_by_path.into_values().collect(),
+            unmanaged_by_path.into_values().collect(),
+        ))
+    }
+
+    fn unmanaged_items_for_agent(&self, agent_id: &str) -> Result<Vec<UnmanagedItemDto>, String> {
+        self.db.with_conn(|connection| {
             let mut statement = connection
                 .prepare(
-                    "SELECT id, skill_id, path, managed, target_id, unmanaged_id
-                     FROM (
-                         SELECT 'target:' || id AS id,
-                                skill_id,
-                                target_path AS path,
-                                1 AS managed,
-                                id AS target_id,
-                                NULL AS unmanaged_id
-                         FROM skill_targets
-                         WHERE agent_id = ?1
-                         UNION ALL
-                         SELECT 'unmanaged:' || id AS id,
-                                COALESCE(inferred_skill_id, '') AS skill_id,
-                                path,
-                                0 AS managed,
-                                NULL AS target_id,
-                                id AS unmanaged_id
-                         FROM unmanaged_items
-                         WHERE agent_id = ?1 AND item_type IN ('skill', 'agent_skill')
-                     )
-                     ORDER BY path, managed DESC, id",
+                    "SELECT id, item_type, agent_id, path, inferred_skill_id, hash, reason
+                     FROM unmanaged_items
+                     WHERE agent_id = ?1 AND item_type IN ('skill', 'agent_skill')
+                     ORDER BY path, id",
                 )
                 .map_err(|error| error.to_string())?;
             let rows = statement
-                .query_map([SHARED_SKILLS_AGENT_ID], |row| {
-                    Ok((
-                        row.get::<_, String>(0)?,
-                        row.get::<_, String>(1)?,
-                        row.get::<_, String>(2)?,
-                        row.get::<_, bool>(3)?,
-                        row.get::<_, Option<String>>(4)?,
-                        row.get::<_, Option<String>>(5)?,
-                    ))
+                .query_map([agent_id], |row| {
+                    let reason = row.get::<_, String>(6)?;
+                    Ok(UnmanagedItemDto {
+                        id: row.get(0)?,
+                        item_type: row.get(1)?,
+                        agent_id: row.get(2)?,
+                        path: row.get(3)?,
+                        inferred_skill_id: row.get(4)?,
+                        hash: row.get(5)?,
+                        read_only: reason == "agent_builtin_read_only",
+                        reason,
+                    })
                 })
                 .map_err(|error| error.to_string())?;
             let mut values = Vec::new();
             for row in rows {
                 values.push(row.map_err(|error| error.to_string())?);
             }
-            Ok::<_, String>(values)
-        })?;
-        let mut rows_by_path: BTreeMap<PathBuf, InheritedSkillRow> = BTreeMap::new();
-        for row in rows {
-            let key = fsutil::normalized_path(Path::new(&row.2));
-            match rows_by_path.get(&key) {
-                Some(existing) if existing.3 || !row.3 => {}
-                _ => {
-                    rows_by_path.insert(key, row);
-                }
-            }
-        }
-        Ok(rows_by_path
-            .into_values()
-            .map(
-                |(id, skill_id, path, managed, target_id, unmanaged_id)| InheritedSkillDetail {
-                    id,
-                    skill_id: if skill_id.trim().is_empty() {
-                        infer_name_from_path(&path)
-                    } else {
-                        skill_id
-                    },
-                    resolved_path: resolved_target_path(&path),
-                    path,
-                    managed,
-                    target_id,
-                    unmanaged_id,
-                },
-            )
-            .collect())
+            Ok(values)
+        })
     }
 
     fn applied_packs_for_agent(&self, agent_id: &str) -> Result<Vec<AppliedPackSummary>, String> {
@@ -5724,6 +5732,18 @@ fn existing_target_mode(path: &Path) -> &'static str {
     }
 }
 
+fn unmanaged_skill_name(item: &UnmanagedItemDto) -> &str {
+    item.inferred_skill_id
+        .as_deref()
+        .filter(|skill_id| !skill_id.trim().is_empty())
+        .or_else(|| {
+            Path::new(&item.path)
+                .file_name()
+                .and_then(|name| name.to_str())
+        })
+        .unwrap_or(&item.path)
+}
+
 fn unmanaged_delete_path_allowed(root: &Path, path: &Path) -> bool {
     if path == root || root.is_symlink() {
         return false;
@@ -5740,7 +5760,7 @@ fn unmanaged_delete_path_allowed(root: &Path, path: &Path) -> bool {
     path.starts_with(&root) && path != root
 }
 
-fn shared_adopt_path_allowed(shared_root: &Path, path: &Path) -> bool {
+fn shared_skill_mutation_path_allowed(shared_root: &Path, path: &Path) -> bool {
     let shared_parent_is_link = shared_root
         .parent()
         .is_some_and(|parent| parent.is_symlink());
@@ -5792,7 +5812,7 @@ fn ensure_shared_adopt_source_unchanged(
     path: &Path,
     expected_hash: &str,
 ) -> Result<(), String> {
-    if !shared_adopt_path_allowed(shared_root, path) {
+    if !shared_skill_mutation_path_allowed(shared_root, path) {
         return Err(format!(
             "Shared skill '{}' is no longer below a trusted .agents skill root; the source was preserved.",
             path.display()

--- a/src-tauri/src/skills/v2/tests.rs
+++ b/src-tauri/src/skills/v2/tests.rs
@@ -71,6 +71,59 @@ fn fresh_service(label: &str) -> (TempHome, Service, std::sync::MutexGuard<'stat
     (home, svc, lock)
 }
 
+fn add_center_test_skill(svc: &Service, source_dir: &str, skill_id: &str) -> PathBuf {
+    let source = write_skill(
+        &svc.home.join("test-sources"),
+        source_dir,
+        skill_id,
+        Some("center"),
+    );
+    svc.execute_add_center_skill(
+        AddCenterSkillInput {
+            source_path: source.display().to_string(),
+            source_type: "local_folder".to_string(),
+            source_uri: None,
+            imported_from_agent: None,
+            imported_from_path: None,
+            multi: None,
+            import_mode: None,
+        },
+        vec![],
+    )
+    .unwrap();
+    PathBuf::from(svc.get_skill_detail(skill_id).unwrap().summary.center_path)
+}
+
+fn insert_shared_managed_target(
+    svc: &Service,
+    target_id: &str,
+    skill_id: &str,
+    target_path: &Path,
+    actual_mode: &str,
+) {
+    let source_hash = svc.get_skill_detail(skill_id).unwrap().summary.current_hash;
+    let current_hash = (actual_mode == "copy").then(|| fsutil::hash_dir(target_path));
+    svc.db()
+        .with_conn(|connection| {
+            connection
+                .execute(
+                    "INSERT INTO skill_targets(id, skill_id, agent_id, target_path, install_mode, actual_mode, source_hash, current_hash, status, created_at, updated_at)
+                     VALUES (?1, ?2, 'agents', ?3, ?4, ?4, ?5, ?6, 'ok', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')",
+                    params![
+                        target_id,
+                        skill_id,
+                        target_path.display().to_string(),
+                        actual_mode,
+                        source_hash,
+                        current_hash,
+                    ],
+                )
+                .map(|_| ())
+                .map_err(|error| error.to_string())
+        })
+        .unwrap();
+}
+
 // ── Hash stability ────────────────────────────────────────────────
 
 #[test]
@@ -2568,6 +2621,214 @@ fn delete_skill_target_distributions_removes_multiple_targets() {
         .is_empty());
 }
 
+#[test]
+#[cfg(unix)]
+fn delete_shared_managed_leaf_unlinks_only_target_and_preserves_center_skill() {
+    let (_home, svc, _lock) = fresh_service("delete-shared-managed-leaf");
+    let center = add_center_test_skill(&svc, "shared-managed-source", "shared-managed");
+    let shared_root = svc.home.join(".agents/skills");
+    fs::create_dir_all(&shared_root).unwrap();
+    let target_path = shared_root.join("shared-managed");
+    std::os::unix::fs::symlink(&center, &target_path).unwrap();
+    insert_shared_managed_target(
+        &svc,
+        "tgt-shared-managed-delete",
+        "shared-managed",
+        &target_path,
+        "link",
+    );
+    svc.db()
+        .with_conn(|connection| {
+            connection
+                .execute(
+                    "INSERT INTO skill_target_claims(id, target_id, claim_type, pack_id, created_at)
+                     VALUES ('clm-shared-managed-delete', 'tgt-shared-managed-delete', 'direct', NULL, '2026-01-01T00:00:00Z')",
+                    [],
+                )
+                .map(|_| ())
+                .map_err(|error| error.to_string())
+        })
+        .unwrap();
+
+    let result = svc
+        .delete_skill_target_distributions(vec!["tgt-shared-managed-delete".to_string()])
+        .unwrap();
+
+    assert_eq!(result.deleted, 1);
+    assert!(result.failures.is_empty());
+    assert!(!target_path.exists());
+    assert!(!target_path.is_symlink());
+    assert!(fsutil::is_skill_dir(&center));
+    let detail = svc.get_skill_detail("shared-managed").unwrap();
+    assert!(detail.targets.is_empty());
+    assert_eq!(detail.summary.center_path, center.display().to_string());
+    let claim_count = svc
+        .db()
+        .with_conn(|connection| {
+            connection
+                .query_row(
+                    "SELECT COUNT(*) FROM skill_target_claims WHERE id = 'clm-shared-managed-delete'",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .map_err(|error| error.to_string())
+        })
+        .unwrap();
+    assert_eq!(claim_count, 0);
+}
+
+#[test]
+fn delete_shared_managed_skill_rejects_root_outside_and_traversal_paths() {
+    let (_home, svc, _lock) = fresh_service("delete-shared-managed-boundary");
+    add_center_test_skill(&svc, "shared-boundary-source", "shared-boundary");
+    let shared_root = svc.home.join(".agents/skills");
+    fs::create_dir_all(shared_root.join("nested")).unwrap();
+    let outside = write_skill(
+        &svc.home.join("Documents"),
+        "outside",
+        "outside-skill",
+        Some("outside"),
+    );
+    let traversal = shared_root
+        .join("nested")
+        .join("..")
+        .join("..")
+        .join("..")
+        .join("Documents")
+        .join("outside");
+    insert_shared_managed_target(
+        &svc,
+        "tgt-shared-managed-boundary",
+        "shared-boundary",
+        &shared_root.join("initial"),
+        "copy",
+    );
+
+    for unsafe_path in [&shared_root, &outside, &traversal] {
+        svc.db()
+            .with_conn(|connection| {
+                connection
+                    .execute(
+                        "UPDATE skill_targets SET target_path = ?1 WHERE id = 'tgt-shared-managed-boundary'",
+                        [unsafe_path.display().to_string()],
+                    )
+                    .map(|_| ())
+                    .map_err(|error| error.to_string())
+            })
+            .unwrap();
+
+        let result = svc
+            .delete_skill_target_distributions(vec!["tgt-shared-managed-boundary".to_string()])
+            .unwrap();
+
+        assert_eq!(result.deleted, 0);
+        assert_eq!(result.failures.len(), 1);
+        assert!(result.failures[0]
+            .error
+            .contains("trusted .agents skill root"));
+        let target_count = svc
+            .db()
+            .with_conn(|connection| {
+                connection
+                    .query_row(
+                        "SELECT COUNT(*) FROM skill_targets WHERE id = 'tgt-shared-managed-boundary'",
+                        [],
+                        |row| row.get::<_, i64>(0),
+                    )
+                    .map_err(|error| error.to_string())
+            })
+            .unwrap();
+        assert_eq!(target_count, 1);
+        assert!(unsafe_path.exists());
+    }
+}
+
+#[test]
+#[cfg(unix)]
+fn shared_managed_and_unmanaged_deletes_reject_symlinked_owner_boundaries() {
+    let (_home, svc, _lock) = fresh_service("delete-shared-symlinked-boundaries");
+    add_center_test_skill(&svc, "shared-symlink-source", "shared-symlink-managed");
+    let agents_root = svc.home.join(".agents");
+    let shared_root = agents_root.join("skills");
+    let managed_path = write_skill(
+        &shared_root,
+        "shared-managed",
+        "shared-symlink-managed",
+        Some("managed"),
+    );
+    let unmanaged_path = write_skill(
+        &shared_root,
+        "shared-unmanaged",
+        "shared-symlink-unmanaged",
+        Some("unmanaged"),
+    );
+    svc.scan_one_agent_into_db("agents").unwrap();
+    let unmanaged_id = svc
+        .list_unmanaged()
+        .unwrap()
+        .into_iter()
+        .find(|item| item.path == unmanaged_path.display().to_string())
+        .map(|item| item.id)
+        .expect("shared unmanaged skill found");
+    insert_shared_managed_target(
+        &svc,
+        "tgt-shared-symlink-boundary",
+        "shared-symlink-managed",
+        &managed_path,
+        "copy",
+    );
+
+    let real_shared_root = svc.home.join("shared-skills-real");
+    fs::rename(&shared_root, &real_shared_root).unwrap();
+    std::os::unix::fs::symlink(&real_shared_root, &shared_root).unwrap();
+
+    let managed_root_error = svc
+        .delete_skill_target_distribution("tgt-shared-symlink-boundary")
+        .unwrap_err();
+    let unmanaged_root_error = svc
+        .delete_unmanaged_agent_skill("agents", &unmanaged_id)
+        .unwrap_err();
+    assert!(managed_root_error.contains("trusted .agents skill root"));
+    assert!(unmanaged_root_error.contains("outside 'agents' skill roots"));
+    assert!(managed_path.exists());
+    assert!(unmanaged_path.exists());
+
+    fs::remove_file(&shared_root).unwrap();
+    fs::rename(&real_shared_root, &shared_root).unwrap();
+    let real_agents_root = svc.home.join("agents-root-real");
+    fs::rename(&agents_root, &real_agents_root).unwrap();
+    std::os::unix::fs::symlink(&real_agents_root, &agents_root).unwrap();
+
+    let managed_parent_error = svc
+        .delete_skill_target_distribution("tgt-shared-symlink-boundary")
+        .unwrap_err();
+    let unmanaged_parent_error = svc
+        .delete_unmanaged_agent_skill("agents", &unmanaged_id)
+        .unwrap_err();
+    assert!(managed_parent_error.contains("trusted .agents skill root"));
+    assert!(unmanaged_parent_error.contains("outside 'agents' skill roots"));
+    assert!(managed_path.exists());
+    assert!(unmanaged_path.exists());
+    let target_count = svc
+        .db()
+        .with_conn(|connection| {
+            connection
+                .query_row(
+                    "SELECT COUNT(*) FROM skill_targets WHERE id = 'tgt-shared-symlink-boundary'",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .map_err(|error| error.to_string())
+        })
+        .unwrap();
+    assert_eq!(target_count, 1);
+    assert!(svc
+        .list_unmanaged()
+        .unwrap()
+        .iter()
+        .any(|item| item.id == unmanaged_id));
+}
+
 // ── Delete center skill preview ──────────────────────────────────
 
 #[test]
@@ -2845,6 +3106,44 @@ fn delete_unmanaged_agents_skill_removes_shared_copy() {
 }
 
 #[test]
+#[cfg(unix)]
+fn delete_unmanaged_agents_skill_unlinks_leaf_without_deleting_resolved_target() {
+    let (_home, svc, _lock) = fresh_service("delete-unmanaged-shared-link");
+    let external = write_skill(
+        &svc.home.join("external-skills"),
+        "shared-link-target",
+        "shared-link-target",
+        Some("external"),
+    );
+    let shared_root = svc.home.join(".agents/skills");
+    fs::create_dir_all(&shared_root).unwrap();
+    let shared_link = shared_root.join("shared-link");
+    std::os::unix::fs::symlink(&external, &shared_link).unwrap();
+    svc.refresh().unwrap();
+    let unmanaged = svc
+        .list_unmanaged()
+        .unwrap()
+        .into_iter()
+        .find(|item| {
+            item.agent_id.as_deref() == Some("agents")
+                && item.path == shared_link.display().to_string()
+        })
+        .expect("shared unmanaged link found");
+
+    svc.delete_unmanaged_agent_skill("agents", &unmanaged.id)
+        .unwrap();
+
+    assert!(!shared_link.exists());
+    assert!(!shared_link.is_symlink());
+    assert!(fsutil::is_skill_dir(&external));
+    assert!(svc
+        .list_unmanaged()
+        .unwrap()
+        .iter()
+        .all(|item| item.id != unmanaged.id));
+}
+
+#[test]
 fn delete_unmanaged_agents_skill_rejects_shared_root_and_outside_paths() {
     let (_home, svc, _lock) = fresh_service("delete-unmanaged-shared-boundary");
     let shared_root = svc.home.join(".agents/skills");
@@ -2855,6 +3154,14 @@ fn delete_unmanaged_agents_skill_rejects_shared_root_and_outside_paths() {
         "outside-skill",
         Some("v1"),
     );
+    fs::create_dir_all(shared_root.join("nested")).unwrap();
+    let traversal = shared_root
+        .join("nested")
+        .join("..")
+        .join("..")
+        .join("..")
+        .join("Documents")
+        .join("outside");
     svc.refresh().unwrap();
     let unmanaged = svc
         .list_unmanaged()
@@ -2863,7 +3170,7 @@ fn delete_unmanaged_agents_skill_rejects_shared_root_and_outside_paths() {
         .find(|u| u.agent_id.as_deref() == Some("agents") && u.path == shared.display().to_string())
         .expect("shared unmanaged skill found");
 
-    for unsafe_path in [&shared_root, &outside] {
+    for unsafe_path in [&shared_root, &outside, &traversal] {
         svc.db()
             .with_conn(|connection| {
                 connection
@@ -2947,6 +3254,67 @@ fn delete_unmanaged_agent_skills_removes_multiple_local_copies() {
     assert!(result.failures.is_empty());
     assert!(!first.exists());
     assert!(!second.exists());
+}
+
+#[test]
+fn delete_unmanaged_agents_skills_partial_failure_preserves_failed_inventory() {
+    let (_home, svc, _lock) = fresh_service("delete-unmanaged-shared-partial");
+    let shared_root = svc.home.join(".agents/skills");
+    let removable = write_skill(
+        &shared_root,
+        "shared-removable",
+        "shared-removable",
+        Some("v1"),
+    );
+    let rejected = write_skill(
+        &shared_root,
+        "shared-rejected",
+        "shared-rejected",
+        Some("v1"),
+    );
+    let outside = write_skill(
+        &svc.home.join("Documents"),
+        "outside-preserved",
+        "outside-preserved",
+        Some("v1"),
+    );
+    svc.refresh().unwrap();
+    let inventory = svc.list_unmanaged().unwrap();
+    let removable_id = inventory
+        .iter()
+        .find(|item| item.path == removable.display().to_string())
+        .map(|item| item.id.clone())
+        .expect("removable shared skill found");
+    let rejected_id = inventory
+        .iter()
+        .find(|item| item.path == rejected.display().to_string())
+        .map(|item| item.id.clone())
+        .expect("rejected shared skill found");
+    svc.db()
+        .with_conn(|connection| {
+            connection
+                .execute(
+                    "UPDATE unmanaged_items SET path = ?1 WHERE id = ?2",
+                    params![outside.display().to_string(), rejected_id],
+                )
+                .map_err(|error| error.to_string())
+        })
+        .unwrap();
+
+    let result = svc
+        .delete_unmanaged_agent_skills("agents", vec![removable_id.clone(), rejected_id.clone()])
+        .unwrap();
+
+    assert_eq!(result.deleted, 1);
+    assert_eq!(result.failures.len(), 1);
+    assert_eq!(result.failures[0].unmanaged_id, rejected_id);
+    assert!(!removable.exists());
+    assert!(outside.exists());
+    let remaining = svc.list_unmanaged().unwrap();
+    assert!(remaining.iter().all(|item| item.id != removable_id));
+    assert!(remaining.iter().any(|item| {
+        item.id == result.failures[0].unmanaged_id && item.path == outside.display().to_string()
+    }));
 }
 
 #[test]
@@ -3625,7 +3993,8 @@ fn adopt_shared_agents_conflicts_always_remove_the_shared_source() {
         );
     }
     let detail = svc.get_agent_detail("codex").unwrap();
-    assert!(detail.inherited_skills.is_empty());
+    assert!(detail.inherited_managed_skills.is_empty());
+    assert!(detail.inherited_unmanaged_skills.is_empty());
 }
 
 #[test]
@@ -4643,11 +5012,12 @@ fn shared_skill_projection_reports_state_ids_and_prefers_managed_same_path() {
         .find(|item| item.path == managed_path.display().to_string())
         .map(|item| item.id.clone())
         .expect("managed path starts with a stale unmanaged projection");
-    let unmanaged_id = inventory
+    let unmanaged_item = inventory
         .iter()
         .find(|item| item.path == unmanaged_path.display().to_string())
-        .map(|item| item.id.clone())
+        .cloned()
         .expect("unmanaged shared skill found");
+    let unmanaged_id = unmanaged_item.id.clone();
 
     let source = write_skill(
         &svc.home.join("sources"),
@@ -4669,8 +5039,19 @@ fn shared_skill_projection_reports_state_ids_and_prefers_managed_same_path() {
     )
     .unwrap();
     let source_hash = fsutil::hash_dir(&source);
+    let managed_hash = fsutil::hash_dir(&managed_path);
     svc.db()
         .with_conn(|connection| {
+            let normalized_duplicate = shared_root
+                .join("missing-segment")
+                .join("..")
+                .join("shared-managed");
+            connection
+                .execute(
+                    "UPDATE unmanaged_items SET path = ?1 WHERE id = ?2",
+                    params![normalized_duplicate.display().to_string(), stale_managed_id],
+                )
+                .map_err(|error| error.to_string())?;
             connection
                 .execute(
                     "INSERT INTO skill_targets(id, skill_id, agent_id, target_path, install_mode, actual_mode, source_hash, current_hash, status, created_at, updated_at)
@@ -4678,53 +5059,72 @@ fn shared_skill_projection_reports_state_ids_and_prefers_managed_same_path() {
                     params![
                         managed_path.display().to_string(),
                         source_hash,
-                        fsutil::hash_dir(&managed_path),
+                        managed_hash,
                         "2026-01-01T00:00:00Z",
                     ],
                 )
+                .map_err(|error| error.to_string())?;
+            connection
+                .execute(
+                    "INSERT INTO skill_target_claims(id, target_id, claim_type, pack_id, created_at)
+                     VALUES ('clm-shared-managed', 'tgt-shared-managed', 'direct', NULL, '2026-01-01T00:00:00Z')",
+                    [],
+                )
+                .map(|_| ())
                 .map_err(|error| error.to_string())
         })
         .unwrap();
 
     for agent_id in ["codex", "kimi", "openclaw", "zcode"] {
         let detail = svc.get_agent_detail(agent_id).unwrap();
-        assert_eq!(detail.inherited_skills.len(), 2, "{agent_id}");
+        assert_eq!(detail.inherited_managed_skills.len(), 1, "{agent_id}");
+        assert_eq!(detail.inherited_unmanaged_skills.len(), 1, "{agent_id}");
 
         let managed = detail
-            .inherited_skills
+            .inherited_managed_skills
             .iter()
-            .find(|skill| skill.path == managed_path.display().to_string())
+            .find(|skill| skill.target_path == managed_path.display().to_string())
             .expect("managed shared projection");
-        assert!(managed.managed, "{agent_id}");
-        assert_eq!(managed.id, "target:tgt-shared-managed", "{agent_id}");
+        assert_eq!(managed.id, "tgt-shared-managed", "{agent_id}");
+        assert_eq!(managed.skill_id, "shared-managed", "{agent_id}");
+        assert_eq!(managed.agent_id, "agents", "{agent_id}");
+        assert_eq!(managed.install_mode, "copy", "{agent_id}");
+        assert_eq!(managed.actual_mode, "copy", "{agent_id}");
+        assert_eq!(managed.source_hash, source_hash, "{agent_id}");
         assert_eq!(
-            managed.target_id.as_deref(),
-            Some("tgt-shared-managed"),
+            managed.current_hash.as_deref(),
+            Some(managed_hash.as_str()),
             "{agent_id}"
         );
-        assert_eq!(managed.unmanaged_id, None, "{agent_id}");
-        assert_ne!(
-            managed.id,
-            format!("unmanaged:{stale_managed_id}"),
-            "managed projection must win same-path deduplication for {agent_id}"
-        );
+        assert_eq!(managed.status, "ok", "{agent_id}");
+        assert_eq!(managed.created_at, "2026-01-01T00:00:00Z", "{agent_id}");
+        assert_eq!(managed.updated_at, "2026-01-01T00:00:00Z", "{agent_id}");
+        assert_eq!(managed.claims.len(), 1, "{agent_id}");
+        assert_eq!(managed.claims[0].id, "clm-shared-managed", "{agent_id}");
+        assert_eq!(managed.claims[0].claim_type, "direct", "{agent_id}");
+        assert_eq!(managed.claims[0].pack_id, None, "{agent_id}");
 
         let unmanaged = detail
-            .inherited_skills
+            .inherited_unmanaged_skills
             .iter()
             .find(|skill| skill.path == unmanaged_path.display().to_string())
             .expect("unmanaged shared projection");
-        assert!(!unmanaged.managed, "{agent_id}");
+        assert_eq!(unmanaged.id, unmanaged_id, "{agent_id}");
+        assert_eq!(unmanaged.item_type, unmanaged_item.item_type, "{agent_id}");
+        assert_eq!(unmanaged.agent_id.as_deref(), Some("agents"), "{agent_id}");
         assert_eq!(
-            unmanaged.id,
-            format!("unmanaged:{unmanaged_id}"),
+            unmanaged.inferred_skill_id, unmanaged_item.inferred_skill_id,
             "{agent_id}"
         );
-        assert_eq!(unmanaged.target_id, None, "{agent_id}");
-        assert_eq!(
-            unmanaged.unmanaged_id.as_deref(),
-            Some(unmanaged_id.as_str()),
-            "{agent_id}"
+        assert_eq!(unmanaged.hash, unmanaged_item.hash, "{agent_id}");
+        assert_eq!(unmanaged.reason, unmanaged_item.reason, "{agent_id}");
+        assert_eq!(unmanaged.read_only, unmanaged_item.read_only, "{agent_id}");
+        assert!(
+            detail
+                .inherited_unmanaged_skills
+                .iter()
+                .all(|item| { item.id != stale_managed_id }),
+            "managed projection must win normalized-path deduplication for {agent_id}"
         );
     }
 }
@@ -4770,30 +5170,25 @@ fn shared_skill_consumers_project_shared_skills_as_inherited() {
         let detail = svc.get_agent_detail(agent_id).unwrap();
         assert!(detail.inherits_shared_skills, "{agent_id}");
         assert!(detail.skills.is_empty(), "{agent_id}");
-        assert_eq!(detail.inherited_skills.len(), 3, "{agent_id}");
-        assert!(detail.inherited_skills.iter().any(|skill| {
-            skill.skill_id == "shared-local"
+        assert!(detail.inherited_managed_skills.is_empty(), "{agent_id}");
+        assert_eq!(detail.inherited_unmanaged_skills.len(), 3, "{agent_id}");
+        assert!(detail.inherited_unmanaged_skills.iter().any(|skill| {
+            skill.inferred_skill_id.as_deref() == Some("shared-local")
+                && skill.agent_id.as_deref() == Some("agents")
                 && skill.path == local.display().to_string()
-                && skill.resolved_path.is_none()
-                && !skill.managed
-                && skill.target_id.is_none()
-                && skill.unmanaged_id.is_some()
+                && !skill.read_only
         }));
-        assert!(detail.inherited_skills.iter().any(|skill| {
-            skill.skill_id == "shared-linked"
+        assert!(detail.inherited_unmanaged_skills.iter().any(|skill| {
+            skill.inferred_skill_id.as_deref() == Some("shared-linked")
+                && skill.agent_id.as_deref() == Some("agents")
                 && skill.path == linked.display().to_string()
-                && skill.resolved_path.as_deref() == Some(source.to_string_lossy().as_ref())
-                && !skill.managed
-                && skill.target_id.is_none()
-                && skill.unmanaged_id.is_some()
+                && !skill.read_only
         }));
-        assert!(detail.inherited_skills.iter().any(|skill| {
-            skill.skill_id == "nested-shared"
+        assert!(detail.inherited_unmanaged_skills.iter().any(|skill| {
+            skill.inferred_skill_id.as_deref() == Some("nested-shared")
+                && skill.agent_id.as_deref() == Some("agents")
                 && skill.path == nested.display().to_string()
-                && skill.resolved_path.is_none()
-                && !skill.managed
-                && skill.target_id.is_none()
-                && skill.unmanaged_id.is_some()
+                && !skill.read_only
         }));
     }
 
@@ -4818,7 +5213,8 @@ fn shared_skill_consumers_project_shared_skills_as_inherited() {
 
     let non_consumer = svc.get_agent_detail("claude-code").unwrap();
     assert!(!non_consumer.inherits_shared_skills);
-    assert!(non_consumer.inherited_skills.is_empty());
+    assert!(non_consumer.inherited_managed_skills.is_empty());
+    assert!(non_consumer.inherited_unmanaged_skills.is_empty());
 }
 
 #[test]

--- a/src/components/skills-v2/AgentManagementPage.tsx
+++ b/src/components/skills-v2/AgentManagementPage.tsx
@@ -6,7 +6,7 @@ import { useSkillStoreV2 } from '../../stores/skillStoreV2'
 import { skillApiV2 } from '../../services/skillApiV2'
 import { agentApi, type AgentOutputEvent, type AgentProgramInfo, type CustomAgentConfig } from '../../services/agentApi'
 import { configureAgentHookEvents, getAllHookStatus, installAgentHook, uninstallAgentHook, type HookEventStatus, type HookStatus } from '../../services/tauriApi'
-import type { AgentConfigDocument, AgentDetail, AdoptPreview, ConflictBlocker, DistributionBlockerDecision, DistributionPreview, InheritedSkillDetail, MoveDirectSkillToPackPreview, SkillPackSummary, SkillSummary, UnmanagedItemDto } from '../../services/skillApiV2'
+import type { AgentConfigDocument, AgentDetail, AdoptPreview, ConflictBlocker, DistributionBlockerDecision, DistributionPreview, MoveDirectSkillToPackPreview, SkillPackSummary, SkillSummary, UnmanagedItemDto } from '../../services/skillApiV2'
 import { useSessionStore } from '../../stores/sessionStore'
 import {
   LOCAL_RUNTIME_ENVIRONMENT_ID,
@@ -1102,15 +1102,23 @@ function AgentDetailView({
   const observedSkills = useSkillStoreV2((s) => s.unmanaged).filter((u) => u.agentId === detail.id)
   const unmanaged = observedSkills.filter((item) => showUnmanaged && !isReadOnlyUnmanaged(item))
   const readOnlySkills = observedSkills.filter(isReadOnlyUnmanaged)
-  const inheritedSkills = detail.inheritedSkills ?? []
-  const inheritsSharedSkills = detail.inheritsSharedSkills ?? inheritedSkills.length > 0
+  const inheritedManagedSkills = detail.inheritedManagedSkills ?? []
+  const inheritedUnmanagedSkills = detail.inheritedUnmanagedSkills ?? []
+  const inheritedSkillCount = inheritedManagedSkills.length + inheritedUnmanagedSkills.length
+  const inheritsSharedSkills = detail.inheritsSharedSkills ?? inheritedSkillCount > 0
   const installed = program ? program.status === 'installed' || program.status === 'updateAvailable' : agentInstalled
   const canInstall = Boolean(program?.installCommand)
   const canOpenDownload = Boolean(program?.downloadUrl)
   const canDeleteCustom = program?.isCustom === true
   const installedVersion = program?.installedVersion ?? detail.version
   const latestVersion = program?.latestVersion ?? detail.latestVersion
-  const logicalSkillCount = countLogicalAgentSkills(detail.skills, unmanaged, inheritedSkills, readOnlySkills)
+  const logicalSkillCount = countLogicalAgentSkills(
+    detail.skills,
+    unmanaged,
+    inheritedManagedSkills,
+    inheritedUnmanagedSkills,
+    readOnlySkills,
+  )
   const hasUpdate = installed && Boolean(latestVersion && latestVersion !== installedVersion)
   const versionLabel = installed ? installedVersion || '未知' : '未安装'
   const updateLabel = !installed
@@ -1148,7 +1156,7 @@ function AgentDetailView({
         <div className="sm2__agent-summary-strip" aria-label="Agent 摘要">
           <Stat value={detail.skills.length} label="已管理" />
           {showUnmanaged && <Stat value={unmanaged.length} label="未管理" tone={unmanaged.length > 0 ? 'warn' : 'ok'} />}
-          {inheritsSharedSkills && <Stat value={inheritedSkills.length} label={t('skills.agentManagement.inheritedSkills')} />}
+          {inheritsSharedSkills && <Stat value={inheritedSkillCount} label={t('skills.agentManagement.inheritedSkills')} />}
           {readOnlySkills.length > 0 && <Stat value={readOnlySkills.length} label={t('skills.agentManagement.builtinSkills')} />}
           <Stat value={detail.appliedPacks.length} label="技能包" />
           <Stat value={detail.mcpServers.length + detail.plugins.length} label="MCP/插件" />
@@ -1207,7 +1215,8 @@ function AgentDetailView({
             key={detail.id}
             detail={detail}
             unmanaged={unmanaged}
-            inheritedSkills={inheritedSkills}
+            inheritedManagedSkills={inheritedManagedSkills}
+            inheritedUnmanagedSkills={inheritedUnmanagedSkills}
             readOnlySkills={readOnlySkills}
             showUnmanaged={showUnmanaged}
             busy={busy}
@@ -1257,7 +1266,7 @@ function OverviewTab({
   const unmanagedCount = observedSkills
     .filter((item) => showUnmanaged && !isReadOnlyUnmanaged(item)).length
   const readOnlyCount = observedSkills.filter(isReadOnlyUnmanaged).length
-  const inheritedCount = detail.inheritedSkills?.length ?? 0
+  const inheritedCount = (detail.inheritedManagedSkills?.length ?? 0) + (detail.inheritedUnmanagedSkills?.length ?? 0)
   const appliedIds = new Set(detail.appliedPacks.map((p) => p.packId))
   const available = detail.availablePacks.filter((p) => !appliedIds.has(p.id))
   const validMcpCount = detail.mcpServers.filter((server) => server.valid).length
@@ -1519,7 +1528,8 @@ function OverviewTab({
 function SkillsTab({
   detail,
   unmanaged,
-  inheritedSkills,
+  inheritedManagedSkills,
+  inheritedUnmanagedSkills,
   readOnlySkills,
   showUnmanaged,
   busy,
@@ -1533,7 +1543,8 @@ function SkillsTab({
 }: {
   detail: AgentDetail
   unmanaged: UnmanagedItemDto[]
-  inheritedSkills: InheritedSkillDetail[]
+  inheritedManagedSkills: AgentDetail['skills']
+  inheritedUnmanagedSkills: UnmanagedItemDto[]
   readOnlySkills: UnmanagedItemDto[]
   showUnmanaged: boolean
   busy: boolean
@@ -1571,19 +1582,29 @@ function SkillsTab({
   const [confirmingPackApply, setConfirmingPackApply] = useState(false)
   const [packApplyProgress, setPackApplyProgress] = useState<PackApplyProgress | null>(null)
   const [localNotice, setLocalNotice] = useState<string | null>(null)
-  const inheritsSharedSkills = detail.inheritsSharedSkills ?? inheritedSkills.length > 0
+  const inheritedSkillCount = inheritedManagedSkills.length + inheritedUnmanagedSkills.length
+  const inheritsSharedSkills = detail.inheritsSharedSkills ?? inheritedSkillCount > 0
+  const activeManagedSkills = source === 'agent' ? detail.skills : inheritedManagedSkills
+  const activeUnmanagedSkills = source === 'agent' ? unmanaged : inheritedUnmanagedSkills
+  const capabilities = {
+    addSkill: source === 'agent',
+    managePackRail: source === 'agent',
+    moveToPack: source === 'agent',
+    quickTakeover: source === 'agent',
+  }
   const q = query.trim().toLowerCase()
   const searchedManaged = useMemo(() => {
-    if (!q) return detail.skills
-    return detail.skills.filter((s) =>
+    if (!q) return activeManagedSkills
+    return activeManagedSkills.filter((s) =>
       [
+        s.skillId,
         s.targetPath,
         s.status,
         s.actualMode,
         ...s.claims.map((claim) => claim.packName || claim.claimType),
       ].filter(Boolean).join(' ').toLowerCase().includes(q),
     )
-  }, [q, detail.skills])
+  }, [activeManagedSkills, q])
   const packFilterCounts = useMemo(() => {
     const pack = searchedManaged.filter(hasSkillPackClaim).length
     return { all: searchedManaged.length, pack, standalone: searchedManaged.length - pack }
@@ -1593,34 +1614,15 @@ function SkillsTab({
     return searchedManaged.filter((skill) => packFilter === 'pack' ? hasSkillPackClaim(skill) : !hasSkillPackClaim(skill))
   }, [packFilter, searchedManaged])
   const filteredUnmanaged = useMemo(() => {
-    if (!q) return unmanaged
-    return unmanaged.filter((u) =>
+    if (!q) return activeUnmanagedSkills
+    return activeUnmanagedSkills.filter((u) =>
       [u.inferredSkillId, u.path, u.reason, unmanagedReasonLabel(t, u.reason), unmanagedSourceLabel(t, u)]
         .filter(Boolean)
         .join(' ')
         .toLowerCase()
         .includes(q),
     )
-  }, [q, t, unmanaged])
-  const inheritedManaged = useMemo(
-    () => inheritedSkills.filter((item) => item.managed),
-    [inheritedSkills],
-  )
-  const inheritedUnmanaged = useMemo(
-    () => inheritedSkills.filter((item) => !item.managed),
-    [inheritedSkills],
-  )
-  const selectedInherited = status === 'managed' ? inheritedManaged : inheritedUnmanaged
-  const filteredInherited = useMemo(() => {
-    if (!q) return selectedInherited
-    return selectedInherited.filter((item) =>
-      [item.skillId, item.path, item.resolvedPath]
-        .filter(Boolean)
-        .join(' ')
-        .toLowerCase()
-        .includes(q),
-    )
-  }, [q, selectedInherited])
+  }, [activeUnmanagedSkills, q, t])
   const filteredReadOnly = useMemo(() => {
     if (!q) return readOnlySkills
     return readOnlySkills.filter((item) =>
@@ -1631,14 +1633,14 @@ function SkillsTab({
         .includes(q),
     )
   }, [q, readOnlySkills, t])
-  const [pageResetKey, setPageResetKey] = useState(`${q}|${detail.id}|${source}|${status}`)
-  const currentResetKey = `${q}|${detail.id}|${source}|${status}`
+  const [pageResetKey, setPageResetKey] = useState(`${q}|${detail.id}|${source}|${status}|${packFilter}`)
+  const currentResetKey = `${q}|${detail.id}|${source}|${status}|${packFilter}`
   if (pageResetKey !== currentResetKey) {
     setPageResetKey(currentResetKey)
     if (page !== 1) setPage(1)
   }
+  const shownManaged = filteredManaged.slice(0, page * PAGE_SIZE)
   const shownUnmanaged = filteredUnmanaged.slice(0, page * PAGE_SIZE)
-  const shownInherited = filteredInherited.slice(0, page * PAGE_SIZE)
   const shownReadOnly = filteredReadOnly.slice(0, page * PAGE_SIZE)
   const canManageUnmanaged = filteredUnmanaged
   const quickTakeoverCandidates = useMemo(
@@ -1742,9 +1744,10 @@ function SkillsTab({
       const targetNames = new Map(targets.map((target) => [target.id, pathBasename(target.targetPath) || target.skillId]))
       const result = await skillApiV2.deleteSkillTargetDistributions(ids)
       const failed = result.failures.map((failure) => `${targetNames.get(failure.targetId) || failure.targetId}: ${failure.error}`)
+      const failedIds = new Set(result.failures.map((failure) => failure.targetId))
       await refreshAgentSkills()
-      setSelectedManagedIds(new Set())
-      setManagedSelectionMode(false)
+      setSelectedManagedIds(failedIds)
+      setManagedSelectionMode(failedIds.size > 0)
       setLocalNotice(`已删除 ${result.deleted} 个 Skill 分发${failed.length ? `，${failed.length} 个失败` : ''}`)
       if (failed.length === 0) state.setError(null)
       if (failed.length > 0) state.setError(failed.slice(0, 3).join('\n'))
@@ -1943,6 +1946,9 @@ function SkillsTab({
 
   const selectedManaged = filteredManaged.filter((item) => selectedManagedIds.has(item.id))
   const selectedUnmanaged = filteredUnmanaged.filter((item) => selectedUnmanagedIds.has(item.id))
+  const deletingSharedManaged = batchDeleteTargets?.some(isSharedManagedSkill) ?? false
+  const deletingSharedUnmanaged = batchDeleteUnmanagedTargets?.some(isSharedAgentsUnmanaged) ?? false
+  const deletingSingleSharedUnmanaged = deleteUnmanagedTarget ? isSharedAgentsUnmanaged(deleteUnmanagedTarget) : false
   const confirmBatchDelete = async () => {
     if (!batchDeleteTargets || batchDeleteTargets.length === 0) return
     await deleteManaged(batchDeleteTargets)
@@ -2008,7 +2014,7 @@ function SkillsTab({
               if (status === 'builtin') setStatus('managed')
             }}
           >
-            {t('skills.agentManagement.inheritedSkills')} {inheritedSkills.length}
+            {t('skills.agentManagement.inheritedSkills')} {inheritedSkillCount}
           </button>
         </div>
       )}
@@ -2018,7 +2024,7 @@ function SkillsTab({
           aria-pressed={status === 'managed'}
           onClick={() => setStatus('managed')}
         >
-          {t('skills.agentManagement.managedSkills')} {source === 'shared' ? inheritedManaged.length : detail.skills.length}
+          {t('skills.agentManagement.managedSkills')} {activeManagedSkills.length}
         </button>
         {(source === 'shared' || showUnmanaged) && (
           <button
@@ -2026,7 +2032,7 @@ function SkillsTab({
             aria-pressed={status === 'unmanaged'}
             onClick={() => setStatus('unmanaged')}
           >
-            {t('skills.agentManagement.unmanagedSkills')} {source === 'shared' ? inheritedUnmanaged.length : unmanaged.length}
+            {t('skills.agentManagement.unmanagedSkills')} {activeUnmanagedSkills.length}
           </button>
         )}
         {source === 'agent' && readOnlySkills.length > 0 && (
@@ -2039,7 +2045,7 @@ function SkillsTab({
           </button>
         )}
       </div>
-      {source === 'agent' && status === 'managed' && (
+      {capabilities.managePackRail && status === 'managed' && (
         <AgentPackToggleRail
           detail={detail}
           busy={actionBusy || confirmingPackApply}
@@ -2050,7 +2056,7 @@ function SkillsTab({
       <div className="sm2__toolbar sm2__toolbar--inset sm2__toolbar--split">
         <input className="sm2__search" value={query} onChange={(e) => setQuery(e.target.value)} placeholder="搜索 Skill 名称 / 路径 / 来源 / 原因" />
         <div className="sm2__agent-skill-actions">
-          {source === 'agent' && status === 'managed' && (
+          {status === 'managed' && (
             <label className="sm2__agent-skill-pack-filter">
               <span>{t('skills.agentManagement.packFilter.label')}</span>
               <select
@@ -2064,72 +2070,76 @@ function SkillsTab({
               </select>
             </label>
           )}
-          {source === 'agent' && status === 'managed' ? (
+          {status === 'managed' ? (
             <>
-              <button className="sm2__btn sm2__btn--primary" disabled={actionBusy || state.skills.length === 0} onClick={() => setInstallDialogOpen(true)}>
-                新增SKILL
-              </button>
+              {capabilities.addSkill && (
+                <button className="sm2__btn sm2__btn--primary" disabled={actionBusy || state.skills.length === 0} onClick={() => setInstallDialogOpen(true)}>
+                  新增SKILL
+                </button>
+              )}
               {managedSelectionMode ? (
               <>
-                <span>已选择 {selectedManagedIds.size} 个</span>
+                <span>{t('skills.agentManagement.actions.selected', { count: selectedManagedIds.size })}</span>
                 <button className="sm2__btn" disabled={filteredManaged.length === 0 || actionBusy} onClick={() => setSelectedManagedIds(new Set(filteredManaged.map((item) => item.id)))}>
-                  选择当前
+                  {t('skills.agentManagement.actions.selectCurrent')}
                 </button>
                 <button className="sm2__btn" disabled={selectedManagedIds.size === 0 || actionBusy} onClick={() => setSelectedManagedIds(new Set())}>
-                  清空
+                  {t('skills.agentManagement.actions.clear')}
                 </button>
-                <ActionButton className="sm2__btn sm2__btn--danger" disabled={selectedManaged.length === 0 || actionBusy} busy={managedDeleting} busyLabel="删除中" onClick={() => setBatchDeleteTargets(selectedManaged)}>
-                  批量删除 {selectedManaged.length} 个
+                <ActionButton className="sm2__btn sm2__btn--danger" disabled={selectedManaged.length === 0 || actionBusy} busy={managedDeleting} busyLabel={t('skills.agentManagement.actions.deleting')} onClick={() => setBatchDeleteTargets(selectedManaged)}>
+                  {t('skills.agentManagement.actions.batchDelete', { count: selectedManaged.length })}
                 </ActionButton>
                 <button className="sm2__btn sm2__btn--ghost" disabled={actionBusy} onClick={() => {
                   setSelectedManagedIds(new Set())
                   setManagedSelectionMode(false)
                 }}>
-                  取消多选
+                  {t('skills.agentManagement.actions.cancelSelection')}
                 </button>
               </>
               ) : (
                 <button className="sm2__btn" disabled={filteredManaged.length === 0 || actionBusy} onClick={() => setManagedSelectionMode(true)}>
-                  批量选择
+                  {t('skills.agentManagement.actions.batchSelect')}
                 </button>
               )}
             </>
-          ) : source === 'agent' && status === 'unmanaged' ? (
+          ) : status === 'unmanaged' ? (
             unmanagedSelectionMode ? (
               <>
-                <span>已选择 {selectedUnmanagedIds.size} 个</span>
+                <span>{t('skills.agentManagement.actions.selected', { count: selectedUnmanagedIds.size })}</span>
                 <button className="sm2__btn" disabled={canManageUnmanaged.length === 0 || actionBusy} onClick={() => setSelectedUnmanagedIds(new Set(canManageUnmanaged.map((item) => item.id)))}>
-                  选择当前可接管
+                  {t('skills.agentManagement.actions.selectCurrentAdoptable')}
                 </button>
                 <button className="sm2__btn" disabled={selectedUnmanagedIds.size === 0 || actionBusy} onClick={() => setSelectedUnmanagedIds(new Set())}>
-                  清空
+                  {t('skills.agentManagement.actions.clear')}
                 </button>
-                <ActionButton className="sm2__btn sm2__btn--primary" disabled={selectedUnmanaged.length === 0 || actionBusy} busy={unmanagedAdopting} busyLabel="接管中" onClick={() => setBatchAdoptItems(selectedUnmanaged)}>
-                  接管到中心库
+                <ActionButton className="sm2__btn sm2__btn--primary" disabled={selectedUnmanaged.length === 0 || actionBusy} busy={unmanagedAdopting} busyLabel={t('skills.agentManagement.actions.adopting')} onClick={() => setBatchAdoptItems(selectedUnmanaged)}>
+                  {t('skills.agentManagement.actions.adoptToCenter')}
                 </ActionButton>
-                <ActionButton className="sm2__btn sm2__btn--danger" disabled={selectedUnmanaged.length === 0 || actionBusy} busy={unmanagedDeleting} busyLabel="删除中" onClick={() => setBatchDeleteUnmanagedTargets(selectedUnmanaged)}>
-                  批量删除 {selectedUnmanaged.length} 个
+                <ActionButton className="sm2__btn sm2__btn--danger" disabled={selectedUnmanaged.length === 0 || actionBusy} busy={unmanagedDeleting} busyLabel={t('skills.agentManagement.actions.deleting')} onClick={() => setBatchDeleteUnmanagedTargets(selectedUnmanaged)}>
+                  {t('skills.agentManagement.actions.batchDelete', { count: selectedUnmanaged.length })}
                 </ActionButton>
                 <button className="sm2__btn sm2__btn--ghost" disabled={actionBusy} onClick={() => {
                   setSelectedUnmanagedIds(new Set())
                   setUnmanagedSelectionMode(false)
                 }}>
-                  取消多选
+                  {t('skills.agentManagement.actions.cancelSelection')}
                 </button>
               </>
             ) : (
               <>
-                <ActionButton
-                  className="sm2__btn sm2__btn--primary"
-                  disabled={quickTakeoverCandidates.length === 0 || actionBusy}
-                  busy={unmanagedAdopting}
-                  busyLabel={t('skills.agentManagement.quickTakeover.busy')}
-                  onClick={() => setQuickTakeoverItems(quickTakeoverCandidates)}
-                >
-                  {t('skills.agentManagement.quickTakeover.action', { count: quickTakeoverCandidates.length })}
-                </ActionButton>
+                {capabilities.quickTakeover && (
+                  <ActionButton
+                    className="sm2__btn sm2__btn--primary"
+                    disabled={quickTakeoverCandidates.length === 0 || actionBusy}
+                    busy={unmanagedAdopting}
+                    busyLabel={t('skills.agentManagement.quickTakeover.busy')}
+                    onClick={() => setQuickTakeoverItems(quickTakeoverCandidates)}
+                  >
+                    {t('skills.agentManagement.quickTakeover.action', { count: quickTakeoverCandidates.length })}
+                  </ActionButton>
+                )}
                 <button className="sm2__btn" disabled={canManageUnmanaged.length === 0 || actionBusy} onClick={() => setUnmanagedSelectionMode(true)}>
-                  批量管理
+                  {t('skills.agentManagement.actions.batchManage')}
                 </button>
               </>
             )
@@ -2146,30 +2156,54 @@ function SkillsTab({
         local
       />
 
-      {source === 'agent' && status === 'managed' && (
-        <ManagedSkillCollection
-          skills={filteredManaged}
-          mode={viewMode}
-          selectable={managedSelectionMode}
-          selectedIds={selectedManagedIds}
-          deletingIds={deletingIds}
-          busy={actionBusy}
-          emptyMessage={q || packFilter !== 'all' ? t('skills.agentManagement.packFilter.noResults') : undefined}
-          onToggle={toggleManaged}
-          onDelete={(skill) => deleteManaged([skill])}
-          onMoveToPack={moveToPackOptions.length > 0 ? setMoveToPackTarget : undefined}
-          onOpenSkillDetail={onOpenSkillDetail}
-        />
+      {source === 'shared' && inheritsSharedSkills && status !== 'builtin' && (
+        <div className="sm2__notice sm2__notice--info">
+          {t('skills.agentManagement.inheritedSkillsNotice', { agent: detail.displayName })}
+        </div>
       )}
 
-      {source === 'agent' && status === 'unmanaged' && showUnmanaged && (
+      {status === 'managed' && (
+        <>
+          <ManagedSkillCollection
+            skills={shownManaged}
+            mode={viewMode}
+            selectable={managedSelectionMode}
+            selectedIds={selectedManagedIds}
+            deletingIds={deletingIds}
+            busy={actionBusy}
+            emptyMessage={source === 'shared'
+              ? t('skills.agentManagement.inheritedManagedNoResults')
+              : q || packFilter !== 'all'
+                ? t('skills.agentManagement.packFilter.noResults')
+                : undefined}
+            onToggle={toggleManaged}
+            onDelete={(skill) => {
+              if (source === 'shared') setBatchDeleteTargets([skill])
+              else void deleteManaged([skill])
+            }}
+            onMoveToPack={capabilities.moveToPack && moveToPackOptions.length > 0 ? setMoveToPackTarget : undefined}
+            onOpenSkillDetail={onOpenSkillDetail}
+          />
+          {shownManaged.length < filteredManaged.length && (
+            <button className="sm2__btn sm2__btn--ghost sm2__load-more" onClick={() => setPage((p) => p + 1)}>
+              继续显示 {Math.min(PAGE_SIZE, filteredManaged.length - shownManaged.length)} 个
+            </button>
+          )}
+        </>
+      )}
+
+      {status === 'unmanaged' && (source === 'shared' || showUnmanaged) && (
         <>
           {filteredUnmanaged.length === 0 ? (
             <div className="sm2__empty sm2__empty--compact sm2__unmanaged-empty">
               <span>
-                {unmanaged.length === 0 ? '没有未管理 Skill。若刚手动安装过，可以重新扫描。' : '没有匹配的未管理 Skill'}
+                {source === 'shared'
+                  ? t('skills.agentManagement.inheritedUnmanagedNoResults')
+                  : unmanaged.length === 0
+                    ? '没有未管理 Skill。若刚手动安装过，可以重新扫描。'
+                    : '没有匹配的未管理 Skill'}
               </span>
-              {unmanaged.length === 0 && (
+              {source === 'agent' && unmanaged.length === 0 && (
                 <ActionButton className="sm2__btn" disabled={busy} onClick={() => onScan(detail.id)} busy={scanning} busyLabel="正在扫描">
                   {scanning ? '正在扫描' : '重新扫描此 Agent'}
                 </ActionButton>
@@ -2180,7 +2214,7 @@ function SkillsTab({
               <UnmanagedSkillCollection
                 skills={shownUnmanaged}
                 mode={viewMode}
-                agentId={detail.id}
+                agentId={source === 'shared' ? SHARED_SKILLS_AGENT_ID : detail.id}
                 busy={actionBusy}
                 selectable={unmanagedSelectionMode}
                 selectedIds={selectedUnmanagedIds}
@@ -2244,51 +2278,31 @@ function SkillsTab({
         </>
       )}
 
-      {source === 'shared' && inheritsSharedSkills && status !== 'builtin' && (
-        <>
-          <div className="sm2__notice sm2__notice--info">
-            {t('skills.agentManagement.inheritedSkillsNotice', { agent: detail.displayName })}
-          </div>
-          {filteredInherited.length === 0 ? (
-            <div className="sm2__empty sm2__empty--compact">
-              {t(
-                status === 'managed'
-                  ? 'skills.agentManagement.inheritedManagedNoResults'
-                  : 'skills.agentManagement.inheritedUnmanagedNoResults',
-              )}
-            </div>
-          ) : (
-            <>
-              <InheritedSkillCollection
-                skills={shownInherited}
-                mode={viewMode}
-                busy={actionBusy}
-                adoptingUnmanagedId={adoptingUnmanagedId}
-                onAdopt={onAdopt}
-                onOpenSkillDetail={onOpenSkillDetail}
-              />
-              {shownInherited.length < filteredInherited.length && (
-                <button className="sm2__btn sm2__btn--ghost sm2__load-more" onClick={() => setPage((p) => p + 1)}>
-                  继续显示 {Math.min(PAGE_SIZE, filteredInherited.length - shownInherited.length)} 个
-                </button>
-              )}
-            </>
-          )}
-        </>
-      )}
-
       {batchDeleteTargets && (
         <PreviewDialog
-          title="确认批量删除 Skill？"
-          confirmLabel="确认删除"
-          busyLabel="删除中"
+          title={deletingSharedManaged
+            ? t('skills.agentManagement.sharedDelete.managedTitle')
+            : '确认批量删除 Skill？'}
+          confirmLabel={deletingSharedManaged
+            ? t('skills.agentManagement.sharedDelete.confirm')
+            : '确认删除'}
+          busyLabel={deletingSharedManaged
+            ? t('skills.agentManagement.sharedDelete.busy')
+            : '删除中'}
           destructive
           busy={managedDeleting}
           disabled={batchDeleteTargets.length === 0}
           onCancel={() => setBatchDeleteTargets(null)}
           onConfirm={confirmBatchDelete}
         >
-          <p>{batchDeleteTargets.length}个SKILL 将从当前Agent直接删除，您后续仍旧可以从中心库安装</p>
+          {deletingSharedManaged ? (
+            <>
+              <p>{t('skills.agentManagement.sharedDelete.managedDescription', { count: batchDeleteTargets.length })}</p>
+              <p>{t('skills.agentManagement.sharedDelete.managedPreserved')}</p>
+            </>
+          ) : (
+            <p>{batchDeleteTargets.length}个SKILL 将从当前Agent直接删除，您后续仍旧可以从中心库安装</p>
+          )}
         </PreviewDialog>
       )}
       {batchAdoptItems && (
@@ -2330,9 +2344,15 @@ function SkillsTab({
       )}
       {batchDeleteUnmanagedTargets && (
         <PreviewDialog
-          title="确认批量删除未管理 Skill？"
-          confirmLabel="确认删除"
-          busyLabel="删除中"
+          title={deletingSharedUnmanaged
+            ? t('skills.agentManagement.sharedDelete.unmanagedTitle')
+            : '确认批量删除未管理 Skill？'}
+          confirmLabel={deletingSharedUnmanaged
+            ? t('skills.agentManagement.sharedDelete.confirm')
+            : '确认删除'}
+          busyLabel={deletingSharedUnmanaged
+            ? t('skills.agentManagement.sharedDelete.busy')
+            : '删除中'}
           destructive
           busy={unmanagedDeleting}
           disabled={batchDeleteUnmanagedTargets.length === 0}
@@ -2343,8 +2363,17 @@ function SkillsTab({
             setBatchDeleteUnmanagedTargets(null)
           }}
         >
-          <p><strong>{batchDeleteUnmanagedTargets.length}</strong> 个未管理 Skill 将从当前 Agent 直接删除。</p>
-          <p>这些 Skill 不会写入中心库，删除后无法从 AgentBro 恢复。</p>
+          {deletingSharedUnmanaged ? (
+            <>
+              <p>{t('skills.agentManagement.sharedDelete.unmanagedDescription', { count: batchDeleteUnmanagedTargets.length })}</p>
+              <p>{t('skills.agentManagement.sharedDelete.unmanagedPermanent')}</p>
+            </>
+          ) : (
+            <>
+              <p><strong>{batchDeleteUnmanagedTargets.length}</strong> 个未管理 Skill 将从当前 Agent 直接删除。</p>
+              <p>这些 Skill 不会写入中心库，删除后无法从 AgentBro 恢复。</p>
+            </>
+          )}
         </PreviewDialog>
       )}
       {moveToPackTarget && (
@@ -2364,11 +2393,17 @@ function SkillsTab({
       )}
       {deleteUnmanagedTarget && (
         <PreviewDialog
-          title={t('skills.agentManagement.unmanagedDelete.title', {
-            name: deleteUnmanagedTarget.inferredSkillId || pathBasename(deleteUnmanagedTarget.path) || deleteUnmanagedTarget.id,
-          })}
-          confirmLabel={t('skills.agentManagement.unmanagedDelete.confirm')}
-          busyLabel={t('skills.agentManagement.unmanagedDelete.busy')}
+          title={deletingSingleSharedUnmanaged
+            ? t('skills.agentManagement.sharedDelete.unmanagedTitle')
+            : t('skills.agentManagement.unmanagedDelete.title', {
+              name: deleteUnmanagedTarget.inferredSkillId || pathBasename(deleteUnmanagedTarget.path) || deleteUnmanagedTarget.id,
+            })}
+          confirmLabel={deletingSingleSharedUnmanaged
+            ? t('skills.agentManagement.sharedDelete.confirm')
+            : t('skills.agentManagement.unmanagedDelete.confirm')}
+          busyLabel={deletingSingleSharedUnmanaged
+            ? t('skills.agentManagement.sharedDelete.busy')
+            : t('skills.agentManagement.unmanagedDelete.busy')}
           modalClassName="sm2__modal--unmanaged-delete"
           destructive
           busy={deletingUnmanagedIds.has(deleteUnmanagedTarget.id)}
@@ -2384,7 +2419,10 @@ function SkillsTab({
             }
           }}
         >
-          <p>{t('skills.agentManagement.unmanagedDelete.description')}</p>
+          <p>{deletingSingleSharedUnmanaged
+            ? t('skills.agentManagement.sharedDelete.unmanagedDescription', { count: 1 })
+            : t('skills.agentManagement.unmanagedDelete.description')}</p>
+          {deletingSingleSharedUnmanaged && <p>{t('skills.agentManagement.sharedDelete.unmanagedPermanent')}</p>}
           <code>{deleteUnmanagedTarget.path}</code>
           {deleteUnmanagedError && <div className="sm2__error sm2__modal-inline-error">{deleteUnmanagedError}</div>}
         </PreviewDialog>
@@ -3496,6 +3534,8 @@ function ManagedSkillCard({
   const name = pathBasename(skill.targetPath) || skill.id
   const claims = skill.claims.map((c) => targetClaimLabel(t, c)).filter(Boolean)
   const directlyDistributed = skill.claims.some((claim) => claim.claimType === 'direct')
+  const deleteLabel = t('skills.agentManagement.actions.delete')
+  const deletingLabel = t('skills.agentManagement.actions.deleting')
   return (
     <AgentSkillCard
       name={name}
@@ -3521,16 +3561,18 @@ function ManagedSkillCard({
             {t('skills.moveToPack.action')}
           </button>
         )}
-        <ActionButton className="sm2__btn sm2__btn--danger" disabled={busy && !deleting} busy={deleting} busyLabel="删除中" aria-label={deleting ? `删除中 ${name}` : `删除 ${name}`} onClick={(e) => {
+        <ActionButton className="sm2__btn sm2__btn--danger" disabled={busy && !deleting} busy={deleting} busyLabel={deletingLabel} aria-label={t(deleting
+          ? 'skills.agentManagement.actions.deletingNamed'
+          : 'skills.agentManagement.actions.deleteNamed', { name })} onClick={(e) => {
           e.stopPropagation()
           onDelete(skill)
         }}>
-          删除
+          {deleteLabel}
         </ActionButton>
       </>}
       selectable={selectable}
       selected={selected}
-      selectionLabel={`选择 ${name}`}
+      selectionLabel={t('skills.agentManagement.actions.selectNamed', { name })}
       selectionDisabled={busy}
       deleting={deleting}
       onToggle={() => onToggle(skill.id)}
@@ -3564,6 +3606,8 @@ function ManagedSkillListRow({
   const claims = skill.claims.map((c) => targetClaimLabel(t, c)).filter(Boolean)
   const name = pathBasename(skill.targetPath) || skill.id
   const directlyDistributed = skill.claims.some((claim) => claim.claimType === 'direct')
+  const deleteLabel = t('skills.agentManagement.actions.delete')
+  const deletingLabel = t('skills.agentManagement.actions.deleting')
   return (
     <AgentSkillListRow
       name={name}
@@ -3578,117 +3622,23 @@ function ManagedSkillListRow({
             {t('skills.moveToPack.action')}
           </button>
         )}
-        <ActionButton className="sm2__btn sm2__btn--danger" disabled={busy && !deleting} busy={deleting} busyLabel="删除中" aria-label={deleting ? `删除中 ${name}` : `删除 ${name}`} onClick={(e) => {
+        <ActionButton className="sm2__btn sm2__btn--danger" disabled={busy && !deleting} busy={deleting} busyLabel={deletingLabel} aria-label={t(deleting
+          ? 'skills.agentManagement.actions.deletingNamed'
+          : 'skills.agentManagement.actions.deleteNamed', { name })} onClick={(e) => {
           e.stopPropagation()
           onDelete(skill)
         }}>
-          删除
+          {deleteLabel}
         </ActionButton>
       </>}
       selectable={selectable}
       selected={selected}
-      selectionLabel={`选择 ${name}`}
+      selectionLabel={t('skills.agentManagement.actions.selectNamed', { name })}
       selectionDisabled={busy}
       deleting={deleting}
       onToggle={() => onToggle(skill.id)}
       onOpen={() => onOpenSkillDetail(skill.skillId)}
     />
-  )
-}
-
-function InheritedSkillCollection({
-  skills,
-  mode,
-  busy,
-  adoptingUnmanagedId,
-  onAdopt,
-  onOpenSkillDetail,
-}: {
-  skills: InheritedSkillDetail[]
-  mode: AgentSkillViewMode
-  busy: boolean
-  adoptingUnmanagedId: string | null
-  onAdopt: (agentId: string, unmanagedId: string) => void
-  onOpenSkillDetail: (skillId: string, fallback?: SkillDetailFallback | null) => void
-}) {
-  const { t } = useTranslation()
-  if (mode === 'list') {
-    return (
-      <div className="sm2__agent-skill-list">
-        {skills.map((skill) => {
-          const adopting = skill.unmanagedId !== null && adoptingUnmanagedId === skill.unmanagedId
-          return (
-            <AgentSkillListRow
-              key={skill.id}
-              name={skill.skillId}
-              description={`${t('skills.agentManagement.inheritedSkillsSource')} · ${t(skill.managed
-                ? 'skills.agentManagement.managedSkills'
-                : 'skills.agentManagement.unmanagedSkills')}`}
-              path={skill.path}
-              pathTitle={skill.resolvedPath ?? undefined}
-              actions={!skill.managed && skill.unmanagedId ? (
-                <ActionButton
-                  className="sm2__btn sm2__btn--primary"
-                  disabled={busy && adoptingUnmanagedId !== skill.unmanagedId}
-                  busy={adopting}
-                  busyLabel={t('skills.agentManagement.sharedAdoptBusy')}
-                  onClick={(event) => {
-                    event.stopPropagation()
-                    onAdopt(SHARED_SKILLS_AGENT_ID, skill.unmanagedId!)
-                  }}
-                >
-                  {t('skills.agentManagement.sharedAdoptAction')}
-                </ActionButton>
-              ) : undefined}
-              adopting={adopting}
-              onOpen={() => openInheritedSkill(skill, onOpenSkillDetail)}
-            />
-          )
-        })}
-      </div>
-    )
-  }
-
-  return (
-    <div className="sm2__agent-skill-grid">
-      {skills.map((skill) => {
-        const adopting = skill.unmanagedId !== null && adoptingUnmanagedId === skill.unmanagedId
-        return (
-          <AgentSkillCard
-            key={skill.id}
-            name={skill.skillId}
-            description={t('skills.agentManagement.inheritedSkillsSource')}
-            path={skill.path}
-            pathTitle={skill.resolvedPath ?? undefined}
-            status={(
-              <span className={`sm2__tag sm2__tag--${skill.managed ? 'managed' : 'unmanaged'}`}>
-                {t(skill.managed
-                  ? 'skills.agentManagement.managedSkills'
-                  : 'skills.agentManagement.unmanagedSkills')}
-              </span>
-            )}
-            metadata={<span className="sm2__source-pill">{t('skills.agentManagement.inheritedSkills')}</span>}
-            actions={!skill.managed && skill.unmanagedId ? (
-              <ActionButton
-                className="sm2__btn sm2__btn--primary"
-                disabled={busy && adoptingUnmanagedId !== skill.unmanagedId}
-                busy={adopting}
-                busyLabel={t('skills.agentManagement.sharedAdoptBusy')}
-                onClick={(event) => {
-                  event.stopPropagation()
-                  onAdopt(SHARED_SKILLS_AGENT_ID, skill.unmanagedId!)
-                }}
-              >
-                {t('skills.agentManagement.sharedAdoptAction')}
-              </ActionButton>
-            ) : undefined}
-            adopting={adopting}
-            unmanaged={!skill.managed}
-            onOpen={() => openInheritedSkill(skill, onOpenSkillDetail)}
-          />
-        )
-      })}
-    </div>
   )
 }
 
@@ -3732,17 +3682,19 @@ function UnmanagedSkillCollection({
         const sourceLabel = unmanagedSourceLabel(t, u)
         const actions = readOnly ? undefined : (
           <>
-            <ActionButton className="sm2__btn sm2__btn--primary" disabled={busy && !adopting} busy={adopting} busyLabel="准备接管" onClick={(event) => {
+            <ActionButton className="sm2__btn sm2__btn--primary" disabled={busy && !adopting} busy={adopting} busyLabel={t('skills.agentManagement.actions.preparingAdopt')} onClick={(event) => {
               event.stopPropagation()
               onAdopt(adoptOwnerAgentId(agentId, u), u.id)
             }}>
-              接管
+              {t('skills.agentManagement.actions.adopt')}
             </ActionButton>
-            <ActionButton className="sm2__btn sm2__btn--danger" disabled={busy && !deleting} busy={deleting} busyLabel="删除中" aria-label={deleting ? `删除中 ${name}` : `删除 ${name}`} onClick={(event) => {
+            <ActionButton className="sm2__btn sm2__btn--danger" disabled={busy && !deleting} busy={deleting} busyLabel={t('skills.agentManagement.actions.deleting')} aria-label={t(deleting
+              ? 'skills.agentManagement.actions.deletingNamed'
+              : 'skills.agentManagement.actions.deleteNamed', { name })} onClick={(event) => {
               event.stopPropagation()
               onDelete(u)
             }}>
-              删除
+              {t('skills.agentManagement.actions.delete')}
             </ActionButton>
           </>
         )
@@ -3757,7 +3709,7 @@ function UnmanagedSkillCollection({
               actions={actions}
               selectable={selectable && !readOnly}
               selected={selectable && selectedIds.has(u.id)}
-              selectionLabel={`选择 ${name}`}
+              selectionLabel={t('skills.agentManagement.actions.selectNamed', { name })}
               selectionDisabled={busy}
               deleting={deleting}
               adopting={adopting}
@@ -3781,7 +3733,7 @@ function UnmanagedSkillCollection({
             actions={actions}
             selectable={selectable && !readOnly}
             selected={selectable && selectedIds.has(u.id)}
-            selectionLabel={`选择 ${name}`}
+            selectionLabel={t('skills.agentManagement.actions.selectNamed', { name })}
             selectionDisabled={busy}
             deleting={deleting}
             adopting={adopting}
@@ -3813,13 +3765,15 @@ function uniqueValues(values: string[]) {
 function countLogicalAgentSkills(
   managed: AgentDetail['skills'],
   unmanaged: UnmanagedItemDto[],
-  inherited: InheritedSkillDetail[],
+  inheritedManaged: AgentDetail['skills'],
+  inheritedUnmanaged: UnmanagedItemDto[],
   readOnly: UnmanagedItemDto[],
 ) {
   return new Set([
     ...managed.map((item) => item.skillId || item.id),
     ...unmanaged.map((item) => item.inferredSkillId || item.id),
-    ...inherited.map((item) => item.skillId || item.id),
+    ...inheritedManaged.map((item) => item.skillId || item.id),
+    ...inheritedUnmanaged.map((item) => item.inferredSkillId || item.id),
     ...readOnly.map((item) => item.inferredSkillId || item.id),
   ].filter(Boolean)).size
 }
@@ -3896,6 +3850,10 @@ function isSharedAgentsUnmanaged(item: UnmanagedItemDto) {
   return item.agentId === SHARED_SKILLS_AGENT_ID || isSharedAgentsSkillsPath(item.path)
 }
 
+function isSharedManagedSkill(item: AgentDetail['skills'][number]) {
+  return item.agentId === SHARED_SKILLS_AGENT_ID || isSharedAgentsSkillsPath(item.targetPath)
+}
+
 function isReadOnlyUnmanaged(item: UnmanagedItemDto) {
   return item.readOnly === true || item.reason === 'agent_builtin_read_only'
 }
@@ -3921,21 +3879,6 @@ function openUnmanagedSkill(
     currentHash: item.hash,
     sourceType: 'unmanaged_agent',
     sourceUri: item.path,
-  })
-}
-
-function openInheritedSkill(
-  item: InheritedSkillDetail,
-  onOpenSkillDetail: (skillId: string, fallback?: SkillDetailFallback | null) => void,
-) {
-  onOpenSkillDetail(item.skillId, {
-    id: item.skillId,
-    name: item.skillId,
-    centerPath: item.path,
-    sourceType: 'unmanaged_agent',
-    sourceUri: item.resolvedPath || item.path,
-    status: item.managed ? 'ok' : 'unmanaged',
-    readOnly: true,
   })
 }
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1240,6 +1240,25 @@
       "builtinSkills": "Built-in read-only",
       "builtinSkillsNotice": "{{count}} Skills are provided by {{agent}} and shown read-only. AgentBro will not adopt, overwrite, or delete these files.",
       "builtinSkillsNoResults": "No built-in Skills match this search.",
+      "actions": {
+        "delete": "Delete",
+        "deleting": "Deleting...",
+        "deleteNamed": "Delete {{name}}",
+        "deletingNamed": "Deleting {{name}}",
+        "adopt": "Adopt",
+        "preparingAdopt": "Preparing adoption...",
+        "adopting": "Adopting...",
+        "batchSelect": "Multi-select",
+        "selected": "{{count}} selected",
+        "selectCurrent": "Select current",
+        "selectCurrentAdoptable": "Select current adoptable",
+        "clear": "Clear",
+        "batchDelete": "Delete {{count}} Skills",
+        "adoptToCenter": "Adopt into center library",
+        "cancelSelection": "Cancel selection",
+        "batchManage": "Batch manage",
+        "selectNamed": "Select {{name}}"
+      },
       "unmanagedDelete": {
         "title": "Delete Skill \"{{name}}\"?",
         "confirm": "Delete Permanently",
@@ -1247,6 +1266,16 @@
         "description": "This deletes the local Skill directory from the current Agent. It will not be added to the center library and cannot be restored from there.",
         "deleting": "Deleting Skill \"{{name}}\"...",
         "deleted": "Deleted Skill \"{{name}}\""
+      },
+      "sharedDelete": {
+        "managedTitle": "Remove shared managed Skill?",
+        "unmanagedTitle": "Permanently delete shared unmanaged Skill?",
+        "confirm": "Delete from shared directory",
+        "busy": "Deleting...",
+        "managedDescription": "This removes {{count}} managed Skill from ~/.agents/skills. Every Agent that reads the shared directory will stop seeing it.",
+        "managedPreserved": "The Skill remains in the center library and can be distributed again later.",
+        "unmanagedDescription": "This permanently deletes {{count}} unmanaged Skill from ~/.agents/skills. Every Agent that reads the shared directory is affected.",
+        "unmanagedPermanent": "The Skill is not copied to the center library and cannot be restored by AgentBro. Adopt it instead if you want to keep it."
       },
       "packFilter": {
         "label": "Pack membership",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1241,6 +1241,25 @@
       "builtinSkills": "組み込み読み取り専用",
       "builtinSkillsNotice": "{{count}} 個の Skill は {{agent}} が提供する組み込み機能で、読み取り専用で表示されます。AgentBro はこれらのファイルを引き継ぎ、上書き、削除しません。",
       "builtinSkillsNoResults": "検索条件に一致する組み込み Skill はありません。",
+      "actions": {
+        "delete": "削除",
+        "deleting": "削除中...",
+        "deleteNamed": "{{name}} を削除",
+        "deletingNamed": "{{name}} を削除中",
+        "adopt": "取り込む",
+        "preparingAdopt": "取り込みを準備中...",
+        "adopting": "取り込み中...",
+        "batchSelect": "複数選択",
+        "selected": "{{count}} 件選択済み",
+        "selectCurrent": "現在の項目を選択",
+        "selectCurrentAdoptable": "現在取り込み可能な項目を選択",
+        "clear": "クリア",
+        "batchDelete": "{{count}} 件の Skill を削除",
+        "adoptToCenter": "センターライブラリへ取り込む",
+        "cancelSelection": "選択をキャンセル",
+        "batchManage": "一括管理",
+        "selectNamed": "{{name}} を選択"
+      },
       "unmanagedDelete": {
         "title": "Skill「{{name}}」を削除しますか？",
         "confirm": "完全に削除",
@@ -1248,6 +1267,16 @@
         "description": "現在の Agent からローカル Skill ディレクトリを削除します。センターライブラリには追加されず、そこから復元することもできません。",
         "deleting": "Skill「{{name}}」を削除しています...",
         "deleted": "Skill「{{name}}」を削除しました"
+      },
+      "sharedDelete": {
+        "managedTitle": "共有の管理済み Skill を削除しますか？",
+        "unmanagedTitle": "共有の未管理 Skill を完全に削除しますか？",
+        "confirm": "共有ディレクトリから削除",
+        "busy": "削除中...",
+        "managedDescription": "~/.agents/skills から管理済み Skill {{count}} 個を削除します。共有ディレクトリを読み込むすべての Agent で利用できなくなります。",
+        "managedPreserved": "センターライブラリの Skill は保持され、後で再配布できます。",
+        "unmanagedDescription": "~/.agents/skills から未管理 Skill {{count}} 個を完全に削除します。共有ディレクトリを読み込むすべての Agent に影響します。",
+        "unmanagedPermanent": "Skill はセンターライブラリにコピーされず、AgentBro から復元できません。保持する場合は取り込みを使用してください。"
       },
       "packFilter": {
         "label": "パック所属",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1241,6 +1241,25 @@
       "builtinSkills": "기본 제공 읽기 전용",
       "builtinSkillsNotice": "{{count}}개의 Skill은 {{agent}}에서 기본 제공하며 읽기 전용으로 표시됩니다. AgentBro는 이 파일을 인계, 덮어쓰기 또는 삭제하지 않습니다.",
       "builtinSkillsNoResults": "검색과 일치하는 기본 제공 Skill이 없습니다.",
+      "actions": {
+        "delete": "삭제",
+        "deleting": "삭제 중...",
+        "deleteNamed": "{{name}} 삭제",
+        "deletingNamed": "{{name}} 삭제 중",
+        "adopt": "인계",
+        "preparingAdopt": "인계 준비 중...",
+        "adopting": "인계 중...",
+        "batchSelect": "다중 선택",
+        "selected": "{{count}}개 선택됨",
+        "selectCurrent": "현재 항목 선택",
+        "selectCurrentAdoptable": "현재 인계 가능한 항목 선택",
+        "clear": "지우기",
+        "batchDelete": "Skill {{count}}개 삭제",
+        "adoptToCenter": "중앙 라이브러리로 인계",
+        "cancelSelection": "선택 취소",
+        "batchManage": "일괄 관리",
+        "selectNamed": "{{name}} 선택"
+      },
       "unmanagedDelete": {
         "title": "Skill \"{{name}}\"을(를) 삭제하시겠습니까?",
         "confirm": "영구 삭제",
@@ -1248,6 +1267,16 @@
         "description": "현재 Agent에서 로컬 Skill 디렉터리를 삭제합니다. 중앙 라이브러리에 추가되지 않으며 중앙 라이브러리에서 복원할 수도 없습니다.",
         "deleting": "Skill \"{{name}}\" 삭제 중...",
         "deleted": "Skill \"{{name}}\"을(를) 삭제했습니다"
+      },
+      "sharedDelete": {
+        "managedTitle": "공유 관리 Skill을 제거하시겠습니까?",
+        "unmanagedTitle": "공유 미관리 Skill을 영구 삭제하시겠습니까?",
+        "confirm": "공유 디렉터리에서 삭제",
+        "busy": "삭제 중...",
+        "managedDescription": "~/.agents/skills에서 관리 Skill {{count}}개를 제거합니다. 공유 디렉터리를 읽는 모든 Agent에서 더 이상 사용할 수 없습니다.",
+        "managedPreserved": "중앙 라이브러리의 Skill은 유지되며 나중에 다시 배포할 수 있습니다.",
+        "unmanagedDescription": "~/.agents/skills에서 미관리 Skill {{count}}개를 영구 삭제합니다. 공유 디렉터리를 읽는 모든 Agent가 영향을 받습니다.",
+        "unmanagedPermanent": "Skill은 중앙 라이브러리에 복사되지 않으며 AgentBro에서 복원할 수 없습니다. 보관하려면 인계를 사용하세요."
       },
       "packFilter": {
         "label": "팩 소속",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -1089,6 +1089,25 @@
       "builtinSkills": "Yerleşik salt okunur",
       "builtinSkillsNotice": "{{count}} Skill, {{agent}} tarafından sağlanır ve salt okunur gösterilir. AgentBro bu dosyaları devralmaz, üzerlerine yazmaz veya silmez.",
       "builtinSkillsNoResults": "Bu aramayla eşleşen yerleşik Skill yok.",
+      "actions": {
+        "delete": "Sil",
+        "deleting": "Siliniyor...",
+        "deleteNamed": "{{name}} öğesini sil",
+        "deletingNamed": "{{name}} siliniyor",
+        "adopt": "Devral",
+        "preparingAdopt": "Devralma hazırlanıyor...",
+        "adopting": "Devralınıyor...",
+        "batchSelect": "Çoklu seçim",
+        "selected": "{{count}} seçili",
+        "selectCurrent": "Geçerli öğeleri seç",
+        "selectCurrentAdoptable": "Devralınabilir geçerli öğeleri seç",
+        "clear": "Temizle",
+        "batchDelete": "{{count}} Skill'i sil",
+        "adoptToCenter": "Merkez kütüphaneye devral",
+        "cancelSelection": "Seçimi iptal et",
+        "batchManage": "Toplu yönet",
+        "selectNamed": "{{name}} öğesini seç"
+      },
       "unmanagedDelete": {
         "title": "\"{{name}}\" Skill silinsin mi?",
         "confirm": "Kalıcı Olarak Sil",
@@ -1096,6 +1115,16 @@
         "description": "Bu işlem, yerel Skill dizinini geçerli Agent'tan siler. Merkez kütüphaneye eklenmez ve oradan geri yüklenemez.",
         "deleting": "\"{{name}}\" Skill siliniyor...",
         "deleted": "\"{{name}}\" Skill silindi"
+      },
+      "sharedDelete": {
+        "managedTitle": "Paylaşılan yönetilen Skill kaldırılsın mı?",
+        "unmanagedTitle": "Paylaşılan yönetilmeyen Skill kalıcı olarak silinsin mi?",
+        "confirm": "Paylaşılan dizinden sil",
+        "busy": "Siliniyor...",
+        "managedDescription": "Bu işlem ~/.agents/skills içinden {{count}} yönetilen Skill'i kaldırır. Paylaşılan dizini okuyan tüm Agent'lar artık onu göremez.",
+        "managedPreserved": "Skill merkez kütüphanede kalır ve daha sonra yeniden dağıtılabilir.",
+        "unmanagedDescription": "Bu işlem ~/.agents/skills içinden {{count}} yönetilmeyen Skill'i kalıcı olarak siler. Paylaşılan dizini okuyan tüm Agent'lar etkilenir.",
+        "unmanagedPermanent": "Skill merkez kütüphaneye kopyalanmaz ve AgentBro tarafından geri yüklenemez. Saklamak istiyorsanız bunun yerine devralın."
       },
       "packFilter": {
         "label": "Paket üyeliği",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1281,6 +1281,25 @@
       "builtinSkills": "内置只读",
       "builtinSkillsNotice": "{{count}} 个 Skill 由 {{agent}} 内置提供，仅作只读展示。AgentBro 不会接管、覆盖或删除这些文件。",
       "builtinSkillsNoResults": "没有匹配的内置 Skill。",
+      "actions": {
+        "delete": "删除",
+        "deleting": "删除中",
+        "deleteNamed": "删除 {{name}}",
+        "deletingNamed": "删除中 {{name}}",
+        "adopt": "接管",
+        "preparingAdopt": "准备接管",
+        "adopting": "接管中",
+        "batchSelect": "批量选择",
+        "selected": "已选择 {{count}} 个",
+        "selectCurrent": "选择当前",
+        "selectCurrentAdoptable": "选择当前可接管",
+        "clear": "清空",
+        "batchDelete": "批量删除 {{count}} 个",
+        "adoptToCenter": "接管到中心库",
+        "cancelSelection": "取消多选",
+        "batchManage": "批量管理",
+        "selectNamed": "选择 {{name}}"
+      },
       "unmanagedDelete": {
         "title": "删除 Skill「{{name}}」？",
         "confirm": "直接删除",
@@ -1288,6 +1307,16 @@
         "description": "这会删除当前 Agent 中的本地 Skill 目录，不会写入中心库，也无法从中心库恢复。",
         "deleting": "正在删除 Skill「{{name}}」...",
         "deleted": "已删除 Skill「{{name}}」"
+      },
+      "sharedDelete": {
+        "managedTitle": "移除共享的已管理 Skill？",
+        "unmanagedTitle": "永久删除共享的未管理 Skill？",
+        "confirm": "从共享目录删除",
+        "busy": "删除中...",
+        "managedDescription": "这会从 ~/.agents/skills 移除 {{count}} 个已管理 Skill，所有读取该共享目录的 Agent 都将无法再使用它。",
+        "managedPreserved": "中心库中的 Skill 会保留，之后仍可重新分发。",
+        "unmanagedDescription": "这会从 ~/.agents/skills 永久删除 {{count}} 个未管理 Skill，所有读取该共享目录的 Agent 都会受到影响。",
+        "unmanagedPermanent": "这些 Skill 不会复制到中心库，AgentBro 无法恢复；如果需要保留，请改用接管。"
       },
       "packFilter": {
         "label": "技能包归属",

--- a/src/services/skillApiV2.ts
+++ b/src/services/skillApiV2.ts
@@ -407,16 +407,6 @@ export interface AgentHealthIssue {
   severity: string
 }
 
-export interface InheritedSkillDetail {
-  id: string
-  skillId: string
-  path: string
-  resolvedPath: string | null
-  managed: boolean
-  targetId: string | null
-  unmanagedId: string | null
-}
-
 export interface AgentDetail {
   id: string
   displayName: string
@@ -430,7 +420,8 @@ export interface AgentDetail {
   agentDir?: string | null
   skills: SkillTargetDetail[]
   inheritsSharedSkills?: boolean
-  inheritedSkills?: InheritedSkillDetail[]
+  inheritedManagedSkills: SkillTargetDetail[]
+  inheritedUnmanagedSkills: UnmanagedItemDto[]
   appliedPacks: AppliedPackSummary[]
   availablePacks: SkillPackSummary[]
   mcpServers: McpServerStatus[]

--- a/src/test/i18n.test.ts
+++ b/src/test/i18n.test.ts
@@ -79,5 +79,50 @@ describe('i18n locale completeness', () => {
       '기본 제공 읽기 전용',
       'Yerleşik salt okunur',
     ])
+
+    const sharedDeleteKeys = [
+      'managedTitle',
+      'unmanagedTitle',
+      'confirm',
+      'busy',
+      'managedDescription',
+      'managedPreserved',
+      'unmanagedDescription',
+      'unmanagedPermanent',
+    ]
+    for (const locale of locales) {
+      const sharedDelete = locale.sharedDelete as Record<string, unknown>
+      for (const key of sharedDeleteKeys) {
+        expect(sharedDelete[key], key).toEqual(expect.any(String))
+        expect(String(sharedDelete[key]).trim(), key).not.toBe('')
+      }
+    }
+
+    const actionKeys = [
+      'delete',
+      'deleting',
+      'deleteNamed',
+      'deletingNamed',
+      'adopt',
+      'preparingAdopt',
+      'adopting',
+      'batchSelect',
+      'selected',
+      'selectCurrent',
+      'selectCurrentAdoptable',
+      'clear',
+      'batchDelete',
+      'adoptToCenter',
+      'cancelSelection',
+      'batchManage',
+      'selectNamed',
+    ]
+    for (const locale of locales) {
+      const actions = locale.actions as Record<string, unknown>
+      for (const key of actionKeys) {
+        expect(actions[key], key).toEqual(expect.any(String))
+        expect(String(actions[key]).trim(), key).not.toBe('')
+      }
+    }
   })
 })

--- a/src/test/mcpManagementTab.test.tsx
+++ b/src/test/mcpManagementTab.test.tsx
@@ -24,6 +24,8 @@ const detail: AgentDetail = {
   mcpConfigPath: '/Users/me/.codex/config.toml',
   pluginDir: null,
   skills: [],
+  inheritedManagedSkills: [],
+  inheritedUnmanagedSkills: [],
   appliedPacks: [],
   availablePacks: [],
   mcpServers: [],

--- a/src/test/pluginManagementTab.test.tsx
+++ b/src/test/pluginManagementTab.test.tsx
@@ -23,6 +23,8 @@ const detail: AgentDetail = {
   mcpConfigPath: '/Users/me/.codex/config.toml',
   pluginDir: '/Users/me/.codex/plugins/cache',
   skills: [],
+  inheritedManagedSkills: [],
+  inheritedUnmanagedSkills: [],
   appliedPacks: [],
   availablePacks: [],
   mcpServers: [],

--- a/src/test/skillManagerV2View.test.tsx
+++ b/src/test/skillManagerV2View.test.tsx
@@ -62,6 +62,37 @@ function makeTarget(overrides: Partial<SkillTargetDetail> = {}): SkillTargetDeta
   }
 }
 
+function makeSharedTarget(skillId: string, overrides: Partial<SkillTargetDetail> = {}): SkillTargetDetail {
+  return makeTarget({
+    id: `target-${skillId}`,
+    skillId,
+    agentId: 'agents',
+    targetPath: `/Users/me/.agents/skills/${skillId}`,
+    resolvedTargetPath: `/Users/me/.agentbro/skills/${skillId}`,
+    claims: [{
+      id: `claim-${skillId}`,
+      claimType: 'direct',
+      packId: null,
+      packName: null,
+      createdAt: '2026-01-01T00:00:00Z',
+    }],
+    ...overrides,
+  })
+}
+
+function makeSharedUnmanaged(skillId: string, overrides: Partial<UnmanagedItemDto> = {}): UnmanagedItemDto {
+  return {
+    id: `raw-${skillId}`,
+    itemType: 'skill',
+    agentId: 'agents',
+    path: `/Users/me/.agents/skills/${skillId}`,
+    inferredSkillId: skillId,
+    hash: `hash-${skillId}`,
+    reason: 'not_in_center_library',
+    ...overrides,
+  }
+}
+
 function makeSidebarAgent(id: string, displayName: string, counts: { managed?: number; unmanaged?: number } = {}): AgentSummary {
   return {
     id,
@@ -2665,6 +2696,8 @@ describe('Skill detail slider + agent page render without crashing', () => {
         claims: [{ id: 'claim-1', claimType: 'direct', packId: null, packName: null, createdAt: '2026-01-01T00:00:00Z' }],
       },
     ],
+    inheritedManagedSkills: [],
+    inheritedUnmanagedSkills: [],
     appliedPacks: [],
     availablePacks: [],
     mcpServers: [],
@@ -3354,26 +3387,8 @@ describe('Skill detail slider + agent page render without crashing', () => {
       skillsDir,
       skills: [],
       inheritsSharedSkills: true,
-      inheritedSkills: [
-        {
-          id: 'unmanaged-shared-review',
-          skillId: 'shared-review',
-          path: '/Users/me/.agents/skills/shared-review',
-          resolvedPath: '/Users/me/.agentbro/skills/shared-review',
-          managed: true,
-          targetId: 'target-shared-review',
-          unmanagedId: null,
-        },
-        {
-          id: 'unmanaged-shared-writing',
-          skillId: 'shared-writing',
-          path: '/Users/me/.agents/skills/shared-writing',
-          resolvedPath: null,
-          managed: false,
-          targetId: null,
-          unmanagedId: 'raw-shared-writing',
-        },
-      ],
+      inheritedManagedSkills: [makeSharedTarget('shared-review')],
+      inheritedUnmanagedSkills: [makeSharedUnmanaged('shared-writing')],
     }
     useSkillStoreV2.setState({
       agents: [
@@ -3442,13 +3457,21 @@ describe('Skill detail slider + agent page render without crashing', () => {
     expect(inheritedCard?.querySelector('.sm2__agent-skill-icon')).not.toBeNull()
     expect(inheritedCard?.querySelector('.sm2__agent-skill-card-titleline')).not.toBeNull()
     expect(inheritedCard?.querySelector('code')).toHaveTextContent('/Users/me/.agents/skills/shared-review')
-    expect(within(inheritedCard!).getByText('共享继承', { selector: '.sm2__source-pill' })).toBeInTheDocument()
-    expect(within(inheritedCard!).getByText('已管理')).toBeInTheDocument()
-    expect(within(inheritedCard!).queryByRole('button', { name: /查看详情/ })).not.toBeInTheDocument()
-    expect(within(inheritedCard!).queryByText('接管到中心库')).not.toBeInTheDocument()
-    expect(within(inheritedCard!).queryByText('删除')).not.toBeInTheDocument()
+    expect(within(inheritedCard!).getByText('软连接', { selector: '.sm2__source-pill' })).toBeInTheDocument()
+    expect(within(inheritedCard!).getByText('正常')).toBeInTheDocument()
+    expect(within(inheritedCard!).getByRole('button', { name: '删除 shared-review' })).toBeInTheDocument()
     expect(within(inheritedCard!).queryByRole('checkbox')).not.toBeInTheDocument()
-    expect(within(inheritedCard!).queryByRole('button')).not.toBeInTheDocument()
+    expect(within(inheritedCard!).queryByRole('button', { name: /归入技能包/ })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '批量选择' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '新增SKILL' })).not.toBeInTheDocument()
+
+    fireEvent.click(within(inheritedCard!).getByRole('button', { name: '删除 shared-review' }))
+    expect(document.body.querySelector('.sm2__slideover--skill-detail')).toBeNull()
+    const sharedDeleteDialog = screen.getByRole('heading', { name: '移除共享的已管理 Skill？' }).closest<HTMLElement>('[role="dialog"]')
+    expect(sharedDeleteDialog).not.toBeNull()
+    expect(within(sharedDeleteDialog!).getByText(/所有读取该共享目录的 Agent/)).toBeInTheDocument()
+    expect(within(sharedDeleteDialog!).getByText(/中心库中的 Skill 会保留/)).toBeInTheDocument()
+    fireEvent.click(within(sharedDeleteDialog!).getByRole('button', { name: '取消' }))
 
     fireEvent.click(screen.getByText('列表'))
     const managedInheritedRow = screen.getByText('/Users/me/.agents/skills/shared-review').closest<HTMLElement>('.sm2__object-row')
@@ -3456,8 +3479,8 @@ describe('Skill detail slider + agent page render without crashing', () => {
     expect(managedInheritedRow).toHaveClass('sm2__object-row--path', 'sm2__object-row--clickable')
     expect(managedInheritedRow).toHaveAttribute('role', 'button')
     expect(managedInheritedRow).toHaveAttribute('tabindex', '0')
-    expect(managedInheritedRow).toHaveTextContent('.agents 共享目录 · 已管理')
-    expect(within(managedInheritedRow!).queryByRole('button')).not.toBeInTheDocument()
+    expect(managedInheritedRow).toHaveTextContent('软连接 · 正常 · 直接分发')
+    expect(within(managedInheritedRow!).getByRole('button', { name: '删除 shared-review' })).toBeInTheDocument()
     fireEvent.click(screen.getByText('卡片'))
 
     fireEvent.change(screen.getByPlaceholderText('搜索 Skill 名称 / 路径 / 来源 / 原因'), { target: { value: 'missing-skill' } })
@@ -3478,14 +3501,15 @@ describe('Skill detail slider + agent page render without crashing', () => {
     expect(unmanagedCard?.querySelector('.sm2__agent-skill-icon')).not.toBeNull()
     expect(unmanagedCard?.querySelector('.sm2__agent-skill-card-titleline')).not.toBeNull()
     expect(unmanagedCard?.querySelector('code')).toHaveTextContent('/Users/me/.agents/skills/shared-writing')
-    expect(within(unmanagedCard!).getByText('共享继承', { selector: '.sm2__source-pill' })).toBeInTheDocument()
+    expect(within(unmanagedCard!).getByText('.agents 共享目录', { selector: '.sm2__source-pill' })).toBeInTheDocument()
     expect(within(unmanagedCard!).getByText('未管理')).toBeInTheDocument()
-    expect(within(unmanagedCard!).getByRole('button', { name: '接管到中心库' })).toBeInTheDocument()
-    expect(within(unmanagedCard!).queryByRole('button', { name: /查看详情/ })).not.toBeInTheDocument()
-    expect(within(unmanagedCard!).queryByText('删除')).not.toBeInTheDocument()
+    expect(within(unmanagedCard!).getByRole('button', { name: '接管' })).toBeInTheDocument()
+    expect(within(unmanagedCard!).getByRole('button', { name: '删除 shared-writing' })).toBeInTheDocument()
     expect(within(unmanagedCard!).queryByRole('checkbox')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '批量管理' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /一键接管/ })).not.toBeInTheDocument()
 
-    fireEvent.click(within(unmanagedCard!).getByRole('button', { name: '接管到中心库' }))
+    fireEvent.click(within(unmanagedCard!).getByRole('button', { name: '接管' }))
     expect(document.body.querySelector('.sm2__slideover--skill-detail')).toBeNull()
     await waitFor(() => {
       expect(previewAdopt).toHaveBeenCalledTimes(1)
@@ -3503,8 +3527,49 @@ describe('Skill detail slider + agent page render without crashing', () => {
     expect(inheritedRow).toHaveClass('sm2__object-row--path', 'sm2__object-row--clickable')
     expect(inheritedRow).toHaveAttribute('role', 'button')
     expect(inheritedRow).toHaveAttribute('tabindex', '0')
-    expect(inheritedRow).toHaveTextContent('.agents 共享目录 · 未管理')
-    expect(within(inheritedRow!).getByRole('button', { name: '接管到中心库' })).toBeInTheDocument()
+    expect(inheritedRow).toHaveTextContent('未在中心库 · .agents 共享目录')
+    expect(within(inheritedRow!).getByRole('button', { name: '接管' })).toBeInTheDocument()
+    expect(within(inheritedRow!).getByRole('button', { name: '删除 shared-writing' })).toBeInTheDocument()
+  })
+
+  it('renders shared managed and unmanaged actions from the English action translations', async () => {
+    await i18n.changeLanguage('en')
+    useSkillStoreV2.setState({
+      agents: [makeSidebarAgent('codex', 'Codex')],
+      selectedAgentId: 'codex',
+      selectedAgentDetail: {
+        ...agentDetail,
+        id: 'codex',
+        displayName: 'Codex',
+        iconKey: 'codex',
+        skillsDir: '/Users/me/.codex/skills',
+        inheritsSharedSkills: true,
+        inheritedManagedSkills: [makeSharedTarget('shared-review')],
+        inheritedUnmanagedSkills: [makeSharedUnmanaged('shared-writing')],
+      },
+      unmanaged: [],
+    })
+
+    const { AgentManagementPage } = await import('../components/skills-v2/AgentManagementPage')
+    render(<AgentManagementPage />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Skills (3)' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Inherited 2' }))
+
+    expect(screen.getByRole('button', { name: 'Delete shared-review' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Multi-select' }))
+    expect(screen.getByText('0 selected')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Select current' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Delete 0 Skills' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel selection' }))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Unmanaged 1' }))
+    expect(screen.getByRole('button', { name: 'Adopt' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Delete shared-writing' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Batch manage' }))
+    expect(screen.getByRole('button', { name: 'Select current adoptable' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Adopt into center library' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Cancel selection' })).toBeInTheDocument()
   })
 
   it('deduplicates the top-level Skills count by logical Skill ID across Agent and shared sources', async () => {
@@ -3518,15 +3583,8 @@ describe('Skill detail slider + agent page render without crashing', () => {
         iconKey: 'codex',
         skillsDir: '/Users/me/.codex/skills',
         inheritsSharedSkills: true,
-        inheritedSkills: [{
-          id: 'shared-release-checklist',
-          skillId: 'release-checklist',
-          path: '/Users/me/.agents/skills/release-checklist',
-          resolvedPath: '/Users/me/.agentbro/skills/release-checklist',
-          managed: true,
-          targetId: 'shared-release-checklist',
-          unmanagedId: null,
-        }],
+        inheritedManagedSkills: [makeSharedTarget('release-checklist')],
+        inheritedUnmanagedSkills: [],
       },
       unmanaged: [],
     })
@@ -3539,7 +3597,7 @@ describe('Skill detail slider + agent page render without crashing', () => {
     expect(screen.getByRole('button', { name: '共享继承 1' })).toBeInTheDocument()
   })
 
-  it('opens inherited Skill details without exposing Agent mutation controls', async () => {
+  it('opens shared managed Skill details through the standard managed card', async () => {
     const consumerDetail: AgentDetail = {
       ...agentDetail,
       id: 'codex',
@@ -3548,17 +3606,8 @@ describe('Skill detail slider + agent page render without crashing', () => {
       skillsDir: '/Users/me/.codex/skills',
       skills: [],
       inheritsSharedSkills: true,
-      inheritedSkills: [
-        {
-          id: 'target-shared-review',
-          skillId: 'shared-review',
-          path: '/Users/me/.agents/skills/shared-review',
-          resolvedPath: '/Users/me/.agentbro/skills/shared-review',
-          managed: true,
-          targetId: 'target-shared-review',
-          unmanagedId: null,
-        },
-      ],
+      inheritedManagedSkills: [makeSharedTarget('shared-review')],
+      inheritedUnmanagedSkills: [],
     }
     useSkillStoreV2.setState({
       agents: [makeSidebarAgent('codex', 'Codex')],
@@ -3605,10 +3654,7 @@ describe('Skill detail slider + agent page render without crashing', () => {
     expect(within(slider).getByRole('button', { name: '文件' })).toBeInTheDocument()
     expect(within(slider).getByRole('button', { name: '来源' })).toBeInTheDocument()
     expect(slider.querySelector('.sm2__detail-pills .sm2__tag--ok')).toHaveTextContent('正常')
-    expect(within(slider).queryByRole('button', { name: 'Agent (1)' })).not.toBeInTheDocument()
-    expect(within(slider).queryByRole('button', { name: '同步中心库' })).not.toBeInTheDocument()
-    expect(within(slider).queryByRole('button', { name: /删除/ })).not.toBeInTheDocument()
-    expect(getSkillDetail).not.toHaveBeenCalled()
+    expect(getSkillDetail).toHaveBeenCalledWith('shared-review')
   })
 
   it('keeps shared adoption open when the Agent detail refresh fails without adopting twice', async () => {
@@ -3620,17 +3666,8 @@ describe('Skill detail slider + agent page render without crashing', () => {
       skillsDir: '/Users/me/.codex/skills',
       skills: [],
       inheritsSharedSkills: true,
-      inheritedSkills: [
-        {
-          id: 'unmanaged-shared-retry',
-          skillId: 'shared-retry',
-          path: '/Users/me/.agents/skills/shared-retry',
-          resolvedPath: null,
-          managed: false,
-          targetId: null,
-          unmanagedId: 'raw-shared-retry',
-        },
-      ],
+      inheritedManagedSkills: [],
+      inheritedUnmanagedSkills: [makeSharedUnmanaged('shared-retry')],
     }
     useSkillStoreV2.setState({
       overview: makeOverview(),
@@ -3658,7 +3695,7 @@ describe('Skill detail slider + agent page render without crashing', () => {
       .mockRejectedValueOnce(new Error('shared detail refresh failed'))
       .mockResolvedValue({
         ...consumerDetail,
-        inheritedSkills: [],
+        inheritedUnmanagedSkills: [],
       })
     vi.spyOn(skillApiV2, 'overview').mockResolvedValue(makeOverview())
 
@@ -3667,7 +3704,7 @@ describe('Skill detail slider + agent page render without crashing', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Skills (1)' }))
     fireEvent.click(screen.getByRole('button', { name: '共享继承 1' }))
     fireEvent.click(screen.getByRole('button', { name: '未管理 1' }))
-    fireEvent.click(screen.getByRole('button', { name: '接管到中心库' }))
+    fireEvent.click(screen.getByRole('button', { name: '接管' }))
     fireEvent.click(await screen.findByRole('button', { name: '确认接管' }))
 
     await waitFor(() => expect(getAgentDetail).toHaveBeenCalledTimes(1))
@@ -3691,17 +3728,8 @@ describe('Skill detail slider + agent page render without crashing', () => {
       skillsDir: '/Users/me/.codex/skills',
       skills: [],
       inheritsSharedSkills: true,
-      inheritedSkills: [
-        {
-          id: 'unmanaged-shared-retry',
-          skillId: 'shared-retry',
-          path: '/Users/me/.agents/skills/shared-retry',
-          resolvedPath: null,
-          managed: false,
-          targetId: null,
-          unmanagedId: 'raw-shared-retry',
-        },
-      ],
+      inheritedManagedSkills: [],
+      inheritedUnmanagedSkills: [makeSharedUnmanaged('shared-retry')],
     }
     useSkillStoreV2.setState({
       overview: makeOverview(),
@@ -3727,7 +3755,7 @@ describe('Skill detail slider + agent page render without crashing', () => {
     vi.spyOn(skillApiV2, 'listUnmanaged').mockResolvedValue([])
     vi.spyOn(skillApiV2, 'getAgentDetail').mockResolvedValue({
       ...consumerDetail,
-      inheritedSkills: [],
+      inheritedUnmanagedSkills: [],
     })
     const overview = vi.spyOn(skillApiV2, 'overview').mockResolvedValue(makeOverview())
 
@@ -3736,7 +3764,7 @@ describe('Skill detail slider + agent page render without crashing', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Skills (1)' }))
     fireEvent.click(screen.getByRole('button', { name: '共享继承 1' }))
     fireEvent.click(screen.getByRole('button', { name: '未管理 1' }))
-    fireEvent.click(screen.getByRole('button', { name: '接管到中心库' }))
+    fireEvent.click(screen.getByRole('button', { name: '接管' }))
     const confirmAdopt = await screen.findByRole('button', { name: '确认接管' })
     const overviewCallsBeforeAdopt = overview.mock.calls.length
     overview.mockRejectedValueOnce(new Error('shared overview refresh failed'))
@@ -3763,17 +3791,8 @@ describe('Skill detail slider + agent page render without crashing', () => {
       skillsDir: '/Users/me/.codex/skills',
       skills: [],
       inheritsSharedSkills: true,
-      inheritedSkills: [
-        {
-          id: 'unmanaged-shared-runtime',
-          skillId: 'shared-runtime',
-          path: '/Users/me/.agents/skills/shared-runtime',
-          resolvedPath: null,
-          managed: false,
-          targetId: null,
-          unmanagedId: 'raw-shared-runtime',
-        },
-      ],
+      inheritedManagedSkills: [],
+      inheritedUnmanagedSkills: [makeSharedUnmanaged('shared-runtime')],
     }
     useSkillStoreV2.setState({
       runtimeEnvironmentId: LOCAL_RUNTIME_ENVIRONMENT_ID,
@@ -3807,7 +3826,7 @@ describe('Skill detail slider + agent page render without crashing', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Skills (1)' }))
     fireEvent.click(screen.getByRole('button', { name: '共享继承 1' }))
     fireEvent.click(screen.getByRole('button', { name: '未管理 1' }))
-    fireEvent.click(screen.getByRole('button', { name: '接管到中心库' }))
+    fireEvent.click(screen.getByRole('button', { name: '接管' }))
     await waitFor(() => expect(previewAdopt).toHaveBeenCalledTimes(1))
 
     act(() => {
@@ -3828,17 +3847,8 @@ describe('Skill detail slider + agent page render without crashing', () => {
       skillsDir: '/Users/me/.codex/skills',
       skills: [],
       inheritsSharedSkills: true,
-      inheritedSkills: [
-        {
-          id: 'unmanaged-shared-runtime',
-          skillId: 'shared-runtime',
-          path: '/Users/me/.agents/skills/shared-runtime',
-          resolvedPath: null,
-          managed: false,
-          targetId: null,
-          unmanagedId: 'raw-shared-runtime',
-        },
-      ],
+      inheritedManagedSkills: [],
+      inheritedUnmanagedSkills: [makeSharedUnmanaged('shared-runtime')],
     }
     const localOverview = makeOverview()
     useSkillStoreV2.setState({
@@ -3881,7 +3891,7 @@ describe('Skill detail slider + agent page render without crashing', () => {
     const listUnmanaged = vi.spyOn(skillApiV2, 'listUnmanaged').mockResolvedValue([])
     const getAgentDetail = vi.spyOn(skillApiV2, 'getAgentDetail').mockResolvedValue({
       ...consumerDetail,
-      inheritedSkills: [],
+      inheritedUnmanagedSkills: [],
     })
     const overview = vi.spyOn(skillApiV2, 'overview').mockResolvedValue(makeOverview())
 
@@ -3890,7 +3900,7 @@ describe('Skill detail slider + agent page render without crashing', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Skills (1)' }))
     fireEvent.click(screen.getByRole('button', { name: '共享继承 1' }))
     fireEvent.click(screen.getByRole('button', { name: '未管理 1' }))
-    fireEvent.click(screen.getByRole('button', { name: '接管到中心库' }))
+    fireEvent.click(screen.getByRole('button', { name: '接管' }))
     fireEvent.click(await screen.findByRole('checkbox', { name: /同时加入技能包/ }))
     fireEvent.click(await screen.findByRole('button', { name: '确认接管' }))
     await waitFor(() => expect(executeAdopt).toHaveBeenCalledTimes(1))
@@ -3922,17 +3932,8 @@ describe('Skill detail slider + agent page render without crashing', () => {
       skillsDir: '/Users/me/.codex/skills',
       skills: [],
       inheritsSharedSkills: true,
-      inheritedSkills: [
-        {
-          id: 'unmanaged-shared-runtime',
-          skillId: 'shared-runtime',
-          path: '/Users/me/.agents/skills/shared-runtime',
-          resolvedPath: null,
-          managed: false,
-          targetId: null,
-          unmanagedId: 'raw-shared-runtime',
-        },
-      ],
+      inheritedManagedSkills: [],
+      inheritedUnmanagedSkills: [makeSharedUnmanaged('shared-runtime')],
     }
     useSkillStoreV2.setState({
       runtimeEnvironmentId: LOCAL_RUNTIME_ENVIRONMENT_ID,
@@ -3969,7 +3970,7 @@ describe('Skill detail slider + agent page render without crashing', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Skills (1)' }))
     fireEvent.click(screen.getByRole('button', { name: '共享继承 1' }))
     fireEvent.click(screen.getByRole('button', { name: '未管理 1' }))
-    fireEvent.click(screen.getByRole('button', { name: '接管到中心库' }))
+    fireEvent.click(screen.getByRole('button', { name: '接管' }))
     const confirmAdopt = await screen.findByRole('button', { name: '确认接管' })
     const overviewCallsBeforeAdopt = overview.mock.calls.length
     fireEvent.click(confirmAdopt)
@@ -3982,7 +3983,8 @@ describe('Skill detail slider + agent page render without crashing', () => {
       displayName: remoteAgent.displayName,
       skillsDir: '/home/me/.codex/skills',
       inheritsSharedSkills: false,
-      inheritedSkills: [],
+      inheritedManagedSkills: [],
+      inheritedUnmanagedSkills: [],
     }
     const remoteOverview = {
       ...makeOverview(),
@@ -4011,7 +4013,7 @@ describe('Skill detail slider + agent page render without crashing', () => {
       })
       resolveDetail({
         ...consumerDetail,
-        inheritedSkills: [],
+        inheritedUnmanagedSkills: [],
       })
     })
 
@@ -4032,17 +4034,8 @@ describe('Skill detail slider + agent page render without crashing', () => {
       skillsDir: '/Users/me/.codex/skills',
       skills: [],
       inheritsSharedSkills: true,
-      inheritedSkills: [
-        {
-          id: 'unmanaged-shared-runtime',
-          skillId: 'shared-runtime',
-          path: '/Users/me/.agents/skills/shared-runtime',
-          resolvedPath: null,
-          managed: false,
-          targetId: null,
-          unmanagedId: 'raw-shared-runtime',
-        },
-      ],
+      inheritedManagedSkills: [],
+      inheritedUnmanagedSkills: [makeSharedUnmanaged('shared-runtime')],
     }
     useSkillStoreV2.setState({
       runtimeEnvironmentId: LOCAL_RUNTIME_ENVIRONMENT_ID,
@@ -4069,7 +4062,7 @@ describe('Skill detail slider + agent page render without crashing', () => {
     vi.spyOn(skillApiV2, 'listUnmanaged').mockResolvedValue([])
     vi.spyOn(skillApiV2, 'getAgentDetail').mockResolvedValue({
       ...consumerDetail,
-      inheritedSkills: [],
+      inheritedUnmanagedSkills: [],
     })
     let resolveOverview: (overview: ReturnType<typeof makeOverview>) => void = () => {}
     const overviewPromise = new Promise<ReturnType<typeof makeOverview>>((resolve) => {
@@ -4082,7 +4075,7 @@ describe('Skill detail slider + agent page render without crashing', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Skills (1)' }))
     fireEvent.click(screen.getByRole('button', { name: '共享继承 1' }))
     fireEvent.click(screen.getByRole('button', { name: '未管理 1' }))
-    fireEvent.click(screen.getByRole('button', { name: '接管到中心库' }))
+    fireEvent.click(screen.getByRole('button', { name: '接管' }))
     const confirmAdopt = await screen.findByRole('button', { name: '确认接管' })
     const overviewCallsBeforeAdopt = overview.mock.calls.length
     overview.mockReturnValueOnce(overviewPromise)
@@ -4096,7 +4089,8 @@ describe('Skill detail slider + agent page render without crashing', () => {
       displayName: remoteAgent.displayName,
       skillsDir: '/home/me/.codex/skills',
       inheritsSharedSkills: false,
-      inheritedSkills: [],
+      inheritedManagedSkills: [],
+      inheritedUnmanagedSkills: [],
     }
     const remoteOverview = {
       ...makeOverview(),
@@ -4160,7 +4154,8 @@ describe('Skill detail slider + agent page render without crashing', () => {
         iconKey: 'codex',
         skillsDir: '/Users/me/.codex/skills',
         inheritsSharedSkills: true,
-        inheritedSkills: [],
+        inheritedManagedSkills: [],
+        inheritedUnmanagedSkills: [],
       },
       unmanaged: [],
     })
@@ -4178,15 +4173,10 @@ describe('Skill detail slider + agent page render without crashing', () => {
   })
 
   it('keeps shared status paging within the selected source', async () => {
-    const inheritedSkills = Array.from({ length: 29 }, (_, index) => ({
-      id: `unmanaged-shared-${index}`,
-      skillId: `shared-${index}`,
-      path: `/Users/me/.agents/skills/shared-${index}`,
-      resolvedPath: null,
-      managed: false,
-      targetId: null,
-      unmanagedId: `raw-shared-${index}`,
-    }))
+    const inheritedUnmanagedSkills = Array.from(
+      { length: 29 },
+      (_, index) => makeSharedUnmanaged(`shared-${index}`),
+    )
     useSkillStoreV2.setState({
       agents: [makeSidebarAgent('codex', 'Codex')],
       selectedAgentId: 'codex',
@@ -4198,7 +4188,8 @@ describe('Skill detail slider + agent page render without crashing', () => {
         skillsDir: '/Users/me/.codex/skills',
         skills: [],
         inheritsSharedSkills: true,
-        inheritedSkills,
+        inheritedManagedSkills: [],
+        inheritedUnmanagedSkills,
       },
       unmanaged: [],
     })
@@ -4216,12 +4207,58 @@ describe('Skill detail slider + agent page render without crashing', () => {
     expect(screen.getByRole('button', { name: '未管理 29' })).toBeInTheDocument()
   })
 
+  it('resets managed paging when the pack filter changes', async () => {
+    const inheritedManagedSkills = Array.from({ length: 29 }, (_, index) =>
+      makeSharedTarget(`shared-pack-${index}`, {
+        claims: [{
+          id: `claim-pack-${index}`,
+          claimType: 'pack',
+          packId: 'shared-pack',
+          packName: 'Shared Pack',
+          createdAt: '2026-01-01T00:00:00Z',
+        }],
+      }),
+    )
+    useSkillStoreV2.setState({
+      agents: [makeSidebarAgent('codex', 'Codex')],
+      selectedAgentId: 'codex',
+      selectedAgentDetail: {
+        ...agentDetail,
+        id: 'codex',
+        displayName: 'Codex',
+        iconKey: 'codex',
+        skillsDir: '/Users/me/.codex/skills',
+        skills: [],
+        inheritsSharedSkills: true,
+        inheritedManagedSkills,
+        inheritedUnmanagedSkills: [],
+      },
+      unmanaged: [],
+    })
+
+    const { AgentManagementPage } = await import('../components/skills-v2/AgentManagementPage')
+    render(<AgentManagementPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Skills (29)' }))
+    fireEvent.click(screen.getByRole('button', { name: '共享继承 29' }))
+
+    expect(screen.getByText('shared-pack-27')).toBeInTheDocument()
+    expect(screen.queryByText('shared-pack-28')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: '继续显示 1 个' }))
+    expect(screen.getByText('shared-pack-28')).toBeInTheDocument()
+
+    fireEvent.change(screen.getByLabelText('技能包归属'), { target: { value: 'pack' } })
+
+    expect(screen.queryByText('shared-pack-28')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '继续显示 1 个' })).toBeInTheDocument()
+  })
+
   it('does not expose shared inventory as inherited or unmanaged for a non-consumer', async () => {
     useSkillStoreV2.setState({
       selectedAgentDetail: {
         ...agentDetail,
         inheritsSharedSkills: false,
-        inheritedSkills: [],
+        inheritedManagedSkills: [],
+        inheritedUnmanagedSkills: [],
       },
       unmanaged: [
         {
@@ -4256,17 +4293,8 @@ describe('Skill detail slider + agent page render without crashing', () => {
       skillsDir: '/Users/me/.codex/skills',
       skills: [],
       inheritsSharedSkills: true,
-      inheritedSkills: [
-        {
-          id: 'unmanaged-shared-reset',
-          skillId: 'shared-reset',
-          path: '/Users/me/.agents/skills/shared-reset',
-          resolvedPath: null,
-          managed: false,
-          targetId: null,
-          unmanagedId: 'raw-shared-reset',
-        },
-      ],
+      inheritedManagedSkills: [],
+      inheritedUnmanagedSkills: [makeSharedUnmanaged('shared-reset')],
     }
     useSkillStoreV2.setState({
       agents: [
@@ -4291,7 +4319,8 @@ describe('Skill detail slider + agent page render without crashing', () => {
         selectedAgentDetail: {
           ...agentDetail,
           inheritsSharedSkills: false,
-          inheritedSkills: [],
+          inheritedManagedSkills: [],
+          inheritedUnmanagedSkills: [],
         },
         unmanaged: [
           {
@@ -4716,6 +4745,77 @@ describe('Skill detail slider + agent page render without crashing', () => {
     expect(screen.getByLabelText('选择 release-checklist')).toBeChecked()
   })
 
+  it('confirms global impact before deleting a shared managed Skill by its target ID', async () => {
+    useSkillStoreV2.setState({
+      selectedAgentDetail: {
+        ...agentDetail,
+        id: 'codex',
+        displayName: 'Codex',
+        iconKey: 'codex',
+        inheritsSharedSkills: true,
+        inheritedManagedSkills: [makeSharedTarget('shared-review', { id: 'target-shared-review' })],
+        inheritedUnmanagedSkills: [],
+      },
+      selectedAgentId: 'codex',
+      agents: [makeSidebarAgent('codex', 'Codex')],
+      unmanaged: [],
+    })
+    const deleteTargets = vi.spyOn(skillApiV2, 'deleteSkillTargetDistributions').mockResolvedValue({ deleted: 1, failures: [] })
+    vi.spyOn(skillApiV2, 'listUnmanaged').mockResolvedValue([])
+    vi.spyOn(useSkillStoreV2.getState(), 'loadAgentDetail').mockResolvedValue(undefined)
+    vi.spyOn(useSkillStoreV2.getState(), 'loadOverview').mockResolvedValue(undefined)
+    const { AgentManagementPage } = await import('../components/skills-v2/AgentManagementPage')
+    render(<AgentManagementPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Skills (2)' }))
+    fireEvent.click(screen.getByRole('button', { name: '共享继承 1' }))
+
+    fireEvent.click(screen.getByRole('button', { name: '删除 shared-review' }))
+
+    const dialog = screen.getByRole('dialog', { name: '移除共享的已管理 Skill？' })
+    expect(dialog).toHaveTextContent('所有读取该共享目录的 Agent 都将无法再使用它')
+    expect(dialog).toHaveTextContent('中心库中的 Skill 会保留')
+    expect(deleteTargets).not.toHaveBeenCalled()
+    fireEvent.click(within(dialog).getByRole('button', { name: '从共享目录删除' }))
+
+    await waitFor(() => expect(deleteTargets).toHaveBeenCalledWith(['target-shared-review']))
+  })
+
+  it('batch deletes shared managed Skills through the standard selection controls', async () => {
+    useSkillStoreV2.setState({
+      selectedAgentDetail: {
+        ...agentDetail,
+        id: 'codex',
+        displayName: 'Codex',
+        iconKey: 'codex',
+        inheritsSharedSkills: true,
+        inheritedManagedSkills: [
+          makeSharedTarget('shared-review', { id: 'target-shared-review' }),
+          makeSharedTarget('shared-writing', { id: 'target-shared-writing' }),
+        ],
+        inheritedUnmanagedSkills: [],
+      },
+      selectedAgentId: 'codex',
+      agents: [makeSidebarAgent('codex', 'Codex')],
+      unmanaged: [],
+    })
+    const deleteTargets = vi.spyOn(skillApiV2, 'deleteSkillTargetDistributions').mockResolvedValue({ deleted: 2, failures: [] })
+    vi.spyOn(skillApiV2, 'listUnmanaged').mockResolvedValue([])
+    vi.spyOn(useSkillStoreV2.getState(), 'loadAgentDetail').mockResolvedValue(undefined)
+    vi.spyOn(useSkillStoreV2.getState(), 'loadOverview').mockResolvedValue(undefined)
+    const { AgentManagementPage } = await import('../components/skills-v2/AgentManagementPage')
+    render(<AgentManagementPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Skills (3)' }))
+    fireEvent.click(screen.getByRole('button', { name: '共享继承 2' }))
+    fireEvent.click(screen.getByRole('button', { name: '批量选择' }))
+    fireEvent.click(screen.getByRole('button', { name: '选择当前' }))
+    fireEvent.click(screen.getByRole('button', { name: '批量删除 2 个' }))
+
+    const dialog = screen.getByRole('dialog', { name: '移除共享的已管理 Skill？' })
+    fireEvent.click(within(dialog).getByRole('button', { name: '从共享目录删除' }))
+
+    await waitFor(() => expect(deleteTargets).toHaveBeenCalledWith(['target-shared-review', 'target-shared-writing']))
+  })
+
   it('deletes an unmanaged agent skill from the skill card after confirmation', async () => {
     const deleteUnmanaged = vi.spyOn(skillApiV2, 'deleteUnmanagedAgentSkill').mockResolvedValue(undefined)
     vi.spyOn(skillApiV2, 'listUnmanaged').mockResolvedValue([])
@@ -4735,6 +4835,42 @@ describe('Skill detail slider + agent page render without crashing', () => {
     await waitFor(() => expect(deleteUnmanaged).toHaveBeenCalledWith('claude-code', 'unmanaged-1'))
     expect(loadAgentDetail).toHaveBeenCalledWith('claude-code', true)
     expect(loadOverview).toHaveBeenCalledWith(true)
+  })
+
+  it('permanently deletes a shared unmanaged Skill with owner agents after confirmation', async () => {
+    useSkillStoreV2.setState({
+      selectedAgentDetail: {
+        ...agentDetail,
+        id: 'codex',
+        displayName: 'Codex',
+        iconKey: 'codex',
+        inheritsSharedSkills: true,
+        inheritedManagedSkills: [],
+        inheritedUnmanagedSkills: [makeSharedUnmanaged('shared-writing')],
+      },
+      selectedAgentId: 'codex',
+      agents: [makeSidebarAgent('codex', 'Codex')],
+      unmanaged: [],
+    })
+    const deleteUnmanaged = vi.spyOn(skillApiV2, 'deleteUnmanagedAgentSkill').mockResolvedValue(undefined)
+    vi.spyOn(skillApiV2, 'listUnmanaged').mockResolvedValue([])
+    vi.spyOn(useSkillStoreV2.getState(), 'loadAgentDetail').mockResolvedValue(undefined)
+    vi.spyOn(useSkillStoreV2.getState(), 'loadOverview').mockResolvedValue(undefined)
+    const { AgentManagementPage } = await import('../components/skills-v2/AgentManagementPage')
+    render(<AgentManagementPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Skills (2)' }))
+    fireEvent.click(screen.getByRole('button', { name: '共享继承 1' }))
+    fireEvent.click(screen.getByRole('button', { name: '未管理 1' }))
+
+    fireEvent.click(screen.getByRole('button', { name: '删除 shared-writing' }))
+
+    const dialog = screen.getByRole('dialog', { name: '永久删除共享的未管理 Skill？' })
+    expect(dialog).toHaveTextContent('所有读取该共享目录的 Agent 都会受到影响')
+    expect(dialog).toHaveTextContent('不会复制到中心库')
+    expect(deleteUnmanaged).not.toHaveBeenCalled()
+    fireEvent.click(within(dialog).getByRole('button', { name: '从共享目录删除' }))
+
+    await waitFor(() => expect(deleteUnmanaged).toHaveBeenCalledWith('agents', 'raw-shared-writing'))
   })
 
   it('keeps unmanaged deletion errors visible inside the confirmation dialog', async () => {
@@ -4816,6 +4952,97 @@ describe('Skill detail slider + agent page render without crashing', () => {
     await waitFor(() => expect(deleteUnmanaged).toHaveBeenCalledWith('claude-code', ['unmanaged-1', 'unmanaged-2']))
     expect(loadAgentDetail).toHaveBeenCalledWith('claude-code', true)
     expect(loadOverview).toHaveBeenCalledWith(true)
+  })
+
+  it('batch deletes shared unmanaged Skills with owner agents', async () => {
+    useSkillStoreV2.setState({
+      selectedAgentDetail: {
+        ...agentDetail,
+        id: 'codex',
+        displayName: 'Codex',
+        iconKey: 'codex',
+        inheritsSharedSkills: true,
+        inheritedManagedSkills: [],
+        inheritedUnmanagedSkills: [
+          makeSharedUnmanaged('shared-writing'),
+          makeSharedUnmanaged('shared-review'),
+        ],
+      },
+      selectedAgentId: 'codex',
+      agents: [makeSidebarAgent('codex', 'Codex')],
+      unmanaged: [],
+    })
+    const deleteUnmanaged = vi.spyOn(skillApiV2, 'deleteUnmanagedAgentSkills').mockResolvedValue({ deleted: 2, failures: [] })
+    vi.spyOn(skillApiV2, 'listUnmanaged').mockResolvedValue([])
+    vi.spyOn(useSkillStoreV2.getState(), 'loadAgentDetail').mockResolvedValue(undefined)
+    vi.spyOn(useSkillStoreV2.getState(), 'loadOverview').mockResolvedValue(undefined)
+    const { AgentManagementPage } = await import('../components/skills-v2/AgentManagementPage')
+    render(<AgentManagementPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Skills (3)' }))
+    fireEvent.click(screen.getByRole('button', { name: '共享继承 2' }))
+    fireEvent.click(screen.getByRole('button', { name: '未管理 2' }))
+    fireEvent.click(screen.getByRole('button', { name: '批量管理' }))
+    fireEvent.click(screen.getByRole('button', { name: '选择当前可接管' }))
+    fireEvent.click(screen.getByRole('button', { name: '批量删除 2 个' }))
+
+    const dialog = screen.getByRole('dialog', { name: '永久删除共享的未管理 Skill？' })
+    fireEvent.click(within(dialog).getByRole('button', { name: '从共享目录删除' }))
+
+    await waitFor(() => expect(deleteUnmanaged).toHaveBeenCalledWith('agents', ['raw-shared-writing', 'raw-shared-review']))
+  })
+
+  it('batch adopts shared unmanaged Skills through the standard flow with owner agents', async () => {
+    useSkillStoreV2.setState({
+      selectedAgentDetail: {
+        ...agentDetail,
+        id: 'codex',
+        displayName: 'Codex',
+        iconKey: 'codex',
+        inheritsSharedSkills: true,
+        inheritedManagedSkills: [],
+        inheritedUnmanagedSkills: [
+          makeSharedUnmanaged('shared-writing'),
+          makeSharedUnmanaged('shared-review'),
+        ],
+      },
+      selectedAgentId: 'codex',
+      agents: [makeSidebarAgent('codex', 'Codex')],
+      unmanaged: [],
+    })
+    const execute = vi.spyOn(skillApiV2, 'executeAdoptBatch').mockResolvedValue({
+      items: [
+        { unmanagedId: 'raw-shared-writing', skillId: 'shared-writing', error: null },
+        { unmanagedId: 'raw-shared-review', skillId: 'shared-review', error: null },
+      ],
+      finalizationError: null,
+    })
+    vi.spyOn(skillApiV2, 'listUnmanaged').mockResolvedValue([])
+    vi.spyOn(useSkillStoreV2.getState(), 'loadAgentDetail').mockResolvedValue(undefined)
+    vi.spyOn(useSkillStoreV2.getState(), 'loadOverview').mockResolvedValue(undefined)
+    const { AgentManagementPage } = await import('../components/skills-v2/AgentManagementPage')
+    render(<AgentManagementPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Skills (3)' }))
+    fireEvent.click(screen.getByRole('button', { name: '共享继承 2' }))
+    fireEvent.click(screen.getByRole('button', { name: '未管理 2' }))
+    fireEvent.click(screen.getByRole('button', { name: '批量管理' }))
+    fireEvent.click(screen.getByRole('button', { name: '选择当前可接管' }))
+    fireEvent.click(screen.getByRole('button', { name: '接管到中心库' }))
+    fireEvent.click(screen.getByRole('button', { name: '确认接管' }))
+
+    await waitFor(() => expect(execute).toHaveBeenCalledWith([
+      {
+        agentId: 'agents',
+        unmanagedId: 'raw-shared-writing',
+        option: 'import_cleanup',
+        renamedId: null,
+      },
+      {
+        agentId: 'agents',
+        unmanagedId: 'raw-shared-review',
+        option: 'import_cleanup',
+        renamedId: null,
+      },
+    ]))
   })
 
   it('switches unmanaged skills into a peer tab and batch adopts them like agent sync', async () => {

--- a/src/test/skillStoreV2.test.ts
+++ b/src/test/skillStoreV2.test.ts
@@ -50,6 +50,8 @@ function makeAgentDetail(id: string): AgentDetail {
     mcpConfigPath: null,
     pluginDir: null,
     skills: [],
+    inheritedManagedSkills: [],
+    inheritedUnmanagedSkills: [],
     appliedPacks: [],
     availablePacks: [],
     mcpServers: [],


### PR DESCRIPTION
## Summary
- reuse the standard managed and unmanaged Agent Skill collections for shared inherited Skills
- expose complete shared managed/unmanaged DTOs for local and remote Agent management
- add global-impact delete confirmations and fail-safe shared path mutations
- make remote shared adopt, sync, diagnosis, and alias detachment atomic with recovery artifacts
- keep unsupported shared capabilities hidden through capability flags

## Validation
- pnpm lint
- pnpm test:run (53 files, 645 tests)
- pnpm build
- cargo check --manifest-path src-tauri/Cargo.toml
- cargo test --manifest-path src-tauri/Cargo.toml remote::skill_manager::tests (10 tests)
- targeted shared Rust tests (27 tests)

Closes #92