### PR TITLE
perf: reduce Agent Skill deletion latency

### DIFF
--- a/docs/superpowers/plans/2026-08-03-agent-skill-delete-performance.md
+++ b/docs/superpowers/plans/2026-08-03-agent-skill-delete-performance.md
@@ -1,0 +1,105 @@
+# Agent Skill 删除性能优化实施计划
+
+日期：2026-08-03  
+Issue：#94  
+设计：`docs/superpowers/specs/2026-08-03-agent-skill-delete-performance-design.md`
+
+## 交付目标
+
+在不改变共享 Skill 安全语义的前提下，让删除确认弹窗立即关闭；本地删除不再全量扫描，远端批量删除只构建一次 inventory，并用一次组合请求完成后台校准。
+
+## 任务 1：建立组合刷新数据契约
+
+涉及文件：
+
+- `src-tauri/src/skills/v2/models.rs`
+- `src-tauri/src/skills/v2/commands.rs`
+- `src-tauri/src/skills/v2/service.rs`
+- `src-tauri/src/lib.rs`
+- `src/services/skillApiV2.ts`
+
+步骤：
+
+1. 新增 `AgentSkillViewSnapshot`，包含 Agent detail、overview 和 unmanaged inventory。
+2. 新增 `refresh_agent_skill_view_v2(agent_id)` Tauri command 并注册。
+3. 本地 service 仅从 SQLite 投影快照，不触发扫描或项目加载。
+4. 前端 API 暴露 `refreshAgentSkillView(agentId)`，类型与 Rust DTO 对齐。
+
+验证：新增 Rust/TypeScript 测试，确认组合读取内容一致且不改变数据库。
+
+## 任务 2：实现本地精确删除快路径
+
+涉及文件：
+
+- `src-tauri/src/skills/v2/service.rs`
+- `src-tauri/src/skills/v2/db.rs`
+- `src-tauri/src/skills/v2/tests.rs`
+
+步骤：
+
+1. managed 单删/批删成功后只移除精确 target 和同 owner、同 path 的陈旧 unmanaged 行。
+2. 删除 managed 路径中的 `scan_one_agent_into_db`。
+3. managed 只有实际删除成功时写 recovery snapshot；批量最多写一次。
+4. unmanaged 单删/批删只删除精确文件和 DB 行，不扫描、不写 snapshot。
+5. 保留文件系统失败不删 DB、owner/path/shared 边界校验和逐项失败语义。
+
+验证：覆盖无关陈旧记录保留、同路径记录清理、snapshot 修改时间、零成功批次和 shared 安全回归。
+
+## 任务 3：实现远端单次 inventory 快路径
+
+涉及文件：
+
+- `src-tauri/src/remote/skill_manager.py`
+- `src-tauri/src/remote/skill_manager.rs`
+
+步骤：
+
+1. 将 overview、agent detail、unmanaged 列表拆成接收既有 inventory 的投影 helper。
+2. `agent_detail` 的 pack 投影复用同一 inventory，不再嵌套调用 overview。
+3. 新增远端组合刷新 command，一次 inventory 返回完整快照。
+4. 批量 unmanaged 删除在入口只建立一次 ID map；逐项继续执行实时 owner/path/shared 安全检查。
+5. 保留共享软链接脱离、哈希、原子替换和回滚实现。
+
+验证：脚本测试统计 inventory 调用次数；42 项批删为 1 次，组合刷新为 1 次，并覆盖部分失败。
+
+## 任务 4：实现前端即时关闭与增量状态更新
+
+涉及文件：
+
+- `src/stores/skillStoreV2.ts`
+- `src/components/skills-v2/AgentManagementPage.tsx`
+- `src/services/skillApiV2.ts`
+- `src/i18n/locales/{en,zh,ja,ko,tr}.json`
+
+步骤：
+
+1. Store 新增原子应用组合快照与删除结果的动作。
+2. 删除确认先同步保存目标、关闭弹窗并标记 busy，再发起异步 mutation。
+3. 单删统一走批量 API，成功 ID 从正确的 managed/shared/unmanaged 集合移除。
+4. 部分失败只保留失败项与选择，并显示逐项原因。
+5. 成功后非阻塞调用组合刷新；首次失败自动重试一次，第二次失败提示但不撤销删除。
+6. 使用环境 ID、Agent ID 和 generation 防止旧响应覆盖新页面。
+7. 删除路径不再调用旧的 `refreshAgentSkills` 串行链路或项目刷新。
+
+验证：组件测试在 mutation Promise 未完成时确认弹窗已关闭、卡片 disabled；覆盖成功、部分失败、重试和 stale guard。
+
+## 任务 5：回归与交付
+
+1. 运行相关 Rust 和 Vitest 用例。
+2. 使用 `source-command-check` 依次执行：
+   - `pnpm lint`
+   - `pnpm test:run`
+   - `pnpm build`
+   - `cargo check --manifest-path src-tauri/Cargo.toml`
+3. 复核 diff、生成物和敏感信息，创建 Conventional Commit。
+4. 推送 `codex/issue-94-speed-up-skill-delete`，创建指向 `dev` 的 PR，正文包含 `Closes #94`。
+5. 开启 squash auto-merge 和删除分支，监控 CI，确认 PR 合并且 Issue 关闭。
+
+## 完成标准
+
+- 弹窗关闭不等待 mutation Promise。
+- 本地已知 ID 删除不触发全量扫描。
+- unmanaged 删除不写 recovery snapshot。
+- 远端 42 项批删 mutation 只构建一次 inventory。
+- 后台校准只发一次组合请求，不刷新项目。
+- 所有共享安全回归和必需校验通过。

--- a/docs/superpowers/specs/2026-08-03-agent-skill-delete-performance-design.md
+++ b/docs/superpowers/specs/2026-08-03-agent-skill-delete-performance-design.md
@@ -1,0 +1,309 @@
+# Agent Skill 删除性能优化设计
+
+日期：2026-08-03
+Issue：#94
+状态：已确认，待实现计划
+
+## 背景
+
+Agent 管理页删除已管理或未管理 Skill 时，确认弹窗会保持忙碌约 1–2 秒。卡顿来自真实的同步工作，而不是卡片组件复用本身：
+
+- 本地删除已知目标后仍会全量扫描所属 Agent 或 `~/.agents/skills`。
+- 扫描会递归发现 Skill、重新计算目录 SHA-256，并逐项更新 SQLite。
+- 当前机器的 `~/.agents/skills` 约 194 MB；一次等价的只读哈希约耗时 1.4 秒。
+- 删除返回后，前端串行请求 `listUnmanaged → getAgentDetail → loadOverview`，而 `loadOverview` 内部又请求一次 `listUnmanaged`。
+- 远端每个请求都会建立独立 SSH 进程并上传完整 Python 管理脚本。批量删除 42 个未管理 Skill 时，当前实现可能重建约 47 次完整 inventory。
+- 删除流程还会触发无关的项目列表刷新。
+
+用户确认的核心体验目标是：点击确认后弹窗立即关闭，卡片显示“删除中”；成功后消失，失败时保留并显示错误。
+
+## 目标
+
+1. 删除确认弹窗在同一个交互帧内关闭，目标为 100 ms 内。
+2. 已知 ID 的本地删除只更新对应文件和数据库行，不全量扫描其他 Skill。
+3. 远端批量删除只为 mutation 构建一次 inventory。
+4. 删除完成后用一次组合请求校准 Agent detail、overview 和 unmanaged inventory。
+5. 单删、批删、部分失败和后台刷新失败都保持准确、可恢复的界面状态。
+6. 保留共享目录现有的路径边界、软链接脱离、哈希验证、原子替换、回滚和 owner 校验。
+
+## 非目标
+
+- 不做列表虚拟化。
+- 不做 Zustand 全局 selector 重构。
+- 不引入 SSH ControlMaster 或长连接。
+- 不把快照导出改造成通用异步任务系统。
+- 不改变“重新扫描此 Agent”的完整文件系统校准语义。
+- 不削弱 `~/.agents/skills` 的任何安全检查。
+
+## 选定方案
+
+采用端到端删除快路径：
+
+- 前端立即退出确认态，以卡片级 busy 状态表达进行中操作。
+- 本地后端执行精确删除和增量数据库更新。
+- 远端批量删除复用单次 inventory 快照。
+- 删除结果先增量写入当前视图，再以单次组合刷新后台校准。
+
+未采用的方案：
+
+- 仅隐藏弹窗和卡片：只能制造“假快”，不会减少扫描、哈希和 SSH 开销。
+- 全面缓存、订阅和虚拟化重构：范围和风险明显超过本次删除性能问题。
+
+## 交互设计
+
+### 确认与进行中
+
+用户点击确认后：
+
+1. 同步保存本次删除目标的不可变快照。
+2. 立即关闭确认弹窗。
+3. 将目标 ID 加入 `deletingIds` 或 `deletingUnmanagedIds`。
+4. 卡片继续显示，但按钮禁用并显示“删除中”。
+5. 页面其他区域和其他卡片保持可操作。
+
+确认弹窗不再等待删除命令或刷新命令完成。
+
+### 成功
+
+删除命令返回后，按成功 ID 增量更新当前状态：
+
+- Agent 专属已管理：从 `selectedAgentDetail.skills` 移除。
+- 共享继承已管理：从 `selectedAgentDetail.inheritedManagedSkills` 移除。
+- Agent 专属未管理：从全局 `unmanaged` 移除。
+- 共享继承未管理：同时从全局 `unmanaged` 和 `selectedAgentDetail.inheritedUnmanagedSkills` 移除。
+- 更新当前可见计数，清除对应 busy 状态。
+
+成功项不等待 overview 或 detail 重载即可消失。
+
+### 部分失败
+
+- 成功项消失。
+- 失败项保留并恢复正常操作状态。
+- 批量选择只保留失败项，便于重试。
+- 错误提示包含 Skill 名称和后端返回的具体原因。
+- 不重新打开确认弹窗。
+
+### 后台刷新失败
+
+增量 UI 更新完成后启动组合刷新。第一次失败时自动重试一次；第二次仍失败时：
+
+- 不撤销已经成功的删除。
+- 显示“删除成功，但列表刷新失败”的错误。
+- 保留手动“刷新总览”与“重新扫描此 Agent”作为恢复入口。
+
+### 切换 Agent 或运行环境
+
+每次 mutation 和 reconciliation 捕获：
+
+- `runtimeEnvironmentId`
+- `agentId`
+- 单调递增的请求 generation
+
+响应只在运行环境、Agent 和 generation 仍匹配时写入当前选中详情。旧响应不得覆盖用户后来切换到的页面。
+
+## 前端架构
+
+### 删除动作
+
+`SkillsTab` 继续复用现有 managed/unmanaged collection。删除处理统一为三个阶段：
+
+1. `beginDelete(targets)`：关闭弹窗并标记 busy。
+2. `executeDelete(targets)`：调用批量删除 API；单删也走批量 API，以获得一致的成功/失败结果。
+3. `applyDeleteResult(result)`：增量更新 Store，随后启动后台 reconciliation。
+
+不新增共享专用卡片或共享专用列表。
+
+### 组合刷新 DTO
+
+新增 Agent Skill 视图快照：
+
+```ts
+interface AgentSkillViewSnapshot {
+  agentDetail: AgentDetail
+  overview: SkillOverview
+  unmanaged: UnmanagedItemDto[]
+}
+```
+
+新增 API：
+
+```ts
+refreshAgentSkillView(agentId: string): Promise<AgentSkillViewSnapshot>
+```
+
+Store 通过一次 `set` 原子更新：
+
+- `selectedAgentDetail`
+- `overview`
+- `skills`
+- `agents`
+- `packs`
+- `issues`
+- `settings`
+- `unmanaged`
+- `lastOverviewLoadedAt`
+
+这个动作不调用 `loadProjects()`，因为 Skill 删除不会改变项目列表。
+
+### 后台校准
+
+删除结果应用后，异步调用 `refreshAgentSkillView(agentId)`：
+
+- 不阻塞删除完成提示。
+- 不重新设置整页 loading。
+- 一次失败后重试一次。
+- 使用运行环境、Agent 和 generation guard。
+
+现有 `refreshAgentSkills()` 中重复、串行的读取将不再用于删除路径。
+
+## 本地 Rust 后端
+
+### 已管理删除
+
+`delete_skill_target_distribution(s)` 已经知道 target ID、owner 和 target path。成功路径调整为：
+
+1. 校验 target 和共享路径边界。
+2. 精确删除文件、目录或叶子软链接。
+3. 删除 `skill_targets` 行；claims 继续由外键级联删除。
+4. 精确清理同 owner、同 path 的陈旧 `unmanaged_items` 行。
+5. 不调用 `scan_one_agent_into_db`。
+6. 只有 `deleted > 0` 时导出一次 recovery snapshot。
+
+显式重新扫描仍负责发现与本次 mutation 无关的外部文件变化。
+
+### 未管理删除
+
+`delete_unmanaged_agent_skill(s)` 成功路径调整为：
+
+1. 校验 unmanaged ID、owner、路径边界和共享安全约束。
+2. 精确删除目标文件、目录或叶子软链接。
+3. 删除对应 `unmanaged_items` 行。
+4. 不调用 `scan_one_agent_into_db`。
+5. 不导出 recovery snapshot。
+
+`unmanaged_items` 当前不包含在 recovery snapshot 中，因此删除未管理项时重写完整快照没有恢复价值。
+
+### 组合读取
+
+新增 Tauri command：
+
+```text
+refresh_agent_skill_view_v2(agent_id)
+```
+
+本地实现从 SQLite 读取 overview、Agent detail 和 unmanaged inventory，不触发文件系统扫描。命令返回统一的 `AgentSkillViewSnapshot`。
+
+## 远端后端
+
+### 批量未管理删除
+
+当前实现会为每个 unmanaged ID 调用一次 `find_unmanaged()`，从而重复构建 inventory。新流程：
+
+1. 命令开始时构建一次 inventory。
+2. 建立 `unmanaged_id → item` 映射。
+3. 逐项使用快照查找目标。
+4. 每项仍独立执行 owner、路径和共享安全校验。
+5. 返回 `deleted` 和逐项 `failures`。
+
+快照只减少发现开销，不跳过 mutation 时的实时路径安全验证。
+
+### 组合读取
+
+新增远端 command，与本地使用相同 DTO。实现只调用一次 `inventory()`，然后从该快照派生：
+
+- overview
+- selected Agent detail
+- unmanaged inventory
+
+为避免隐藏的重复扫描，相关构造函数拆为接收既有 inventory 的纯投影 helper：
+
+- `overview_from_inventory(...)`
+- `agent_detail_from_inventory(...)`
+- `unmanaged_inventory_from_inventory(...)`
+
+`agent_detail` 构造 available packs 时不得再次调用 `overview()`。
+
+### 安全逻辑
+
+以下逻辑保持原样：
+
+- `shared_skill_mutation_path`
+- center symlink dependent 发现与安全脱离
+- 哈希与 `SKILL.md` 验证
+- 同文件系统 staging、backup、原子替换和回滚
+- 回滚失败时保留 recovery artifacts
+- 普通与共享 owner 严格匹配
+
+安全路径可能因真实目录复制而耗时，但不能为性能目标省略。
+
+## 性能预算
+
+### 前台体验
+
+- 确认弹窗关闭：目标小于 100 ms。
+- 页面在 mutation 期间保持响应。
+- 普通软链接或小目录删除不再包含全量扫描时间。
+- 大型真实目录的物理删除允许继续耗时，但只影响对应卡片的 busy 状态。
+
+### 本地后端
+
+- 已知 ID 删除不调用 `scan_one_agent_into_db`。
+- 未管理删除不写 recovery snapshot。
+- 已管理批量删除最多写一次 snapshot，且 `deleted == 0` 时不写。
+
+### 远端后端
+
+- N 项批量未管理删除：一次 mutation inventory，不随 N 线性增加 inventory 次数。
+- 删除后的 reconciliation：一次 inventory。
+- 42 项批量删除的完整前台/校准流程总计最多两次 inventory。
+- 删除路径不触发项目列表请求。
+
+## 错误语义
+
+- 文件系统删除失败时不得删除数据库行。
+- 数据库删除失败时返回明确错误并保留失败项；DB-only reconciliation 不得假定磁盘已经回滚，错误提示应引导用户执行“重新扫描此 Agent”以校准真实文件状态。
+- shared 安全校验失败时目标和恢复副本必须保留。
+- mutation 成功、reconciliation 失败时以 mutation 结果为准，不伪装成删除失败。
+- 批量 API 必须保留逐项失败，不因一个失败回滚已经成功的独立删除。
+
+## 测试设计
+
+### 前端
+
+1. 点击确认后，在删除 Promise 未完成时弹窗已经关闭。
+2. 未完成项显示 busy 且不可重复操作。
+3. managed 单删成功后立即从正确的专属或共享集合移除。
+4. unmanaged 单删成功后同时更新全局和共享继承集合。
+5. 批量部分失败时成功项消失、失败项保留并保持选择。
+6. reconciliation 只调用一次组合 API，不调用旧的串行刷新链路或项目刷新。
+7. 第一次 reconciliation 失败会重试一次；第二次失败显示准确提示。
+8. 切换 Agent 或运行环境后，旧响应不覆盖新详情。
+
+### 本地 Rust
+
+1. managed 删除保留无关的陈旧 inventory 记录，证明没有隐式全量扫描。
+2. managed 删除精确清理同 owner、同 path 的陈旧 unmanaged 行。
+3. unmanaged 删除保留其他 inventory 行且不触发全量扫描。
+4. unmanaged 删除前后 snapshot 内容和修改时间不变。
+5. managed `deleted == 0` 不更新 snapshot；成功 batch 只更新一次。
+6. shared root、parent symlink、leaf symlink、outside path 和 traversal 回归测试继续通过。
+
+### 远端
+
+1. 42 项批量未管理删除只调用一次 inventory。
+2. mixed owner、stale ID 和部分失败仍返回逐项结果。
+3. 组合刷新只调用一次 inventory。
+4. Agent detail 的 pack 投影不触发第二次 inventory。
+5. 共享同名、别名、链式软链接、symlink root、原子替换与 rollback fault tests 全部继续通过。
+
+### 完整门禁
+
+- `pnpm lint`
+- `pnpm test:run`
+- `pnpm build`
+- `cargo check --manifest-path src-tauri/Cargo.toml`
+- PR CI 的 `cargo fmt --check`、严格 clippy 和全量 `cargo test`
+
+## 交付边界
+
+本 Issue 完成时应同时交付本地与远端快路径、组合刷新、交互状态和回归测试。若性能数据表明剩余卡顿来自卡片重渲染或超大目录物理删除，另开独立 Issue；本任务不顺带进行 Store selector 或虚拟化重构。

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6350,6 +6350,7 @@ pub fn run() {
             skills::v2::commands::execute_move_direct_skill_to_pack,
             skills::v2::commands::list_managed_agents_v2,
             skills::v2::commands::get_agent_detail_v2,
+            skills::v2::commands::refresh_agent_skill_view_v2,
             skills::v2::commands::read_agent_config_file_v2,
             skills::v2::commands::write_agent_config_file_v2,
             skills::v2::commands::list_plugin_inventory_v2,

--- a/src-tauri/src/remote/skill_manager.py
+++ b/src-tauri/src/remote/skill_manager.py
@@ -1117,8 +1117,7 @@ def pack_summary(detail):
     }
 
 
-def overview():
-    skills, agents, unmanaged, targets = inventory()
+def overview_from_inventory(skills, agents, unmanaged, targets):
     details = [pack_detail("default", skills, agents)]
     details.extend(
         pack_detail(pack_id, skills, agents)
@@ -1139,6 +1138,10 @@ def overview():
         "issues": issues,
         "settings": STATE["settings"],
     }
+
+
+def overview():
+    return overview_from_inventory(*inventory())
 
 
 def file_tree(path):
@@ -1388,8 +1391,7 @@ def diagnosis(skills=None, agents=None, unmanaged=None, targets=None):
     return issues
 
 
-def unmanaged_inventory():
-    skills, agents, unmanaged, targets = inventory()
+def unmanaged_inventory_from_inventory(skills, agents, unmanaged, targets):
     by_agent = {agent["id"]: [] for agent in agents}
     for item in unmanaged:
         skill_id = item["inferredSkillId"] or pathlib.Path(item["path"]).name
@@ -1456,6 +1458,10 @@ def unmanaged_inventory():
         "items": sorted(shared_items, key=lambda item: item["name"].lower()),
     })
     return result
+
+
+def unmanaged_inventory():
+    return unmanaged_inventory_from_inventory(*inventory())
 
 
 def find_unmanaged(unmanaged_id):
@@ -1855,11 +1861,17 @@ def apply_pack(pack_id, target_agents, requested_mode, decisions=None):
     return result
 
 
-def agent_detail(agent_id):
+def agent_detail_from_inventory(
+    agent_id,
+    skills,
+    agents,
+    unmanaged,
+    targets,
+    available_packs=None,
+):
     spec = agent_spec(agent_id)
     if not spec:
         raise ValueError("Unknown Agent: " + agent_id)
-    skills, agents, unmanaged, targets = inventory()
     agent = next(item for item in agents if item["id"] == agent_id)
     inherited_managed, inherited_unmanaged = shared_skill_projection(
         agent_id,
@@ -1886,10 +1898,33 @@ def agent_detail(agent_id):
         "inheritedManagedSkills": inherited_managed,
         "inheritedUnmanagedSkills": inherited_unmanaged,
         "appliedPacks": applied,
-        "availablePacks": overview()["packs"],
+        "availablePacks": available_packs if available_packs is not None else overview_from_inventory(
+            skills,
+            agents,
+            unmanaged,
+            targets,
+        )["packs"],
         "mcpServers": [],
         "plugins": [],
         "health": [],
+    }
+
+
+def agent_detail(agent_id):
+    return agent_detail_from_inventory(agent_id, *inventory())
+
+
+def agent_skill_view_snapshot(agent_id):
+    snapshot = inventory()
+    overview_value = overview_from_inventory(*snapshot)
+    return {
+        "agentDetail": agent_detail_from_inventory(
+            agent_id,
+            *snapshot,
+            available_packs=overview_value["packs"],
+        ),
+        "overview": overview_value,
+        "unmanaged": snapshot[2],
     }
 
 
@@ -3008,11 +3043,17 @@ def dispatch():
             if command == "delete_unmanaged_agent_skill"
             else args.get("unmanagedIds", [])
         )
+        unmanaged_by_id = {
+            item["id"]: item
+            for item in inventory()[2]
+        }
         failures = []
         deleted = 0
         for unmanaged_id in ids:
             try:
-                item = find_unmanaged(unmanaged_id)
+                item = unmanaged_by_id.get(unmanaged_id)
+                if not item:
+                    raise ValueError("Unmanaged Skill not found: " + unmanaged_id)
                 remove_unmanaged_item(item, requested_agent_id)
                 deleted += 1
             except Exception as error:
@@ -3243,6 +3284,8 @@ def dispatch():
         return overview()["agents"]
     if command == "get_agent_detail_v2":
         return agent_detail(args["agentId"])
+    if command == "refresh_agent_skill_view_v2":
+        return agent_skill_view_snapshot(args["agentId"])
     if command == "read_agent_config_file_v2":
         return config_document(args["path"])
     if command == "write_agent_config_file_v2":

--- a/src-tauri/src/remote/skill_manager.rs
+++ b/src-tauri/src/remote/skill_manager.rs
@@ -360,6 +360,49 @@ mod tests {
     }
 
     #[test]
+    fn remote_batch_delete_and_composite_refresh_each_build_one_inventory() {
+        let home = std::env::temp_dir().join(format!(
+            "agentbro-remote-skill-manager-fast-delete-test-{}",
+            uuid::Uuid::new_v4()
+        ));
+        let root = home.join(".codex/skills");
+        let ids = (0..42)
+            .map(|index| {
+                let name = format!("delete-{index:02}");
+                write_remote_skill(&root.join(&name), &name, "delete\n");
+                format!("codex::{name}")
+            })
+            .collect::<Vec<_>>();
+
+        let deleted = run_script_with_inventory_count(
+            &home,
+            "delete_unmanaged_agent_skills",
+            serde_json::json!({
+                "agentId": "codex",
+                "unmanagedIds": ids,
+            }),
+        );
+        assert_eq!(deleted["inventoryCalls"], 1);
+        assert_eq!(deleted["result"]["deleted"], 42);
+        assert!(deleted["result"]["failures"]
+            .as_array()
+            .expect("delete failures")
+            .is_empty());
+
+        let refreshed = run_script_with_inventory_count(
+            &home,
+            "refresh_agent_skill_view_v2",
+            serde_json::json!({ "agentId": "codex" }),
+        );
+        assert_eq!(refreshed["inventoryCalls"], 1);
+        assert_eq!(refreshed["result"]["agentDetail"]["id"], "codex");
+        assert!(refreshed["result"]["overview"]["agents"].is_array());
+        assert!(refreshed["result"]["unmanaged"].is_array());
+
+        std::fs::remove_dir_all(home).expect("remove test home");
+    }
+
+    #[test]
     fn remote_response_sanitizes_surrogates() {
         let home = std::env::temp_dir().join(format!(
             "agentbro-remote-skill-manager-surrogate-test-{}",
@@ -1033,6 +1076,28 @@ os.replace = _agentbro_fail_activation_and_rollback
 
     fn run_script(home: &Path, command: &str, args: Value) -> Value {
         let script = render_script(command, args).expect("render remote script");
+        run_rendered_script(home, &script)
+    }
+
+    fn run_script_with_inventory_count(home: &Path, command: &str, args: Value) -> Value {
+        let script = render_script(command, args)
+            .expect("render remote script")
+            .replace(
+                "try:\n    RESPONSE = json_safe(dispatch())",
+                r#"_agentbro_original_inventory = inventory
+_agentbro_inventory_calls = 0
+def inventory():
+    global _agentbro_inventory_calls
+    _agentbro_inventory_calls += 1
+    return _agentbro_original_inventory()
+
+try:
+    _agentbro_result = dispatch()
+    RESPONSE = json_safe({
+        "result": _agentbro_result,
+        "inventoryCalls": _agentbro_inventory_calls,
+    })"#,
+            );
         run_rendered_script(home, &script)
     }
 

--- a/src-tauri/src/skills/v2/commands.rs
+++ b/src-tauri/src/skills/v2/commands.rs
@@ -513,6 +513,11 @@ pub fn get_agent_detail_v2(agent_id: String) -> Result<AgentDetail, String> {
 }
 
 #[tauri::command(async)]
+pub fn refresh_agent_skill_view_v2(agent_id: String) -> Result<AgentSkillViewSnapshot, String> {
+    svc()?.refresh_agent_skill_view(&agent_id)
+}
+
+#[tauri::command(async)]
 pub fn read_agent_config_file_v2(
     agent_id: String,
     path: String,

--- a/src-tauri/src/skills/v2/models.rs
+++ b/src-tauri/src/skills/v2/models.rs
@@ -95,6 +95,14 @@ pub struct SkillManagerOverview {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct AgentSkillViewSnapshot {
+    pub agent_detail: AgentDetail,
+    pub overview: SkillManagerOverview,
+    pub unmanaged: Vec<UnmanagedItemDto>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ProjectSummary {
     pub id: String,
     pub name: String,

--- a/src-tauri/src/skills/v2/service.rs
+++ b/src-tauri/src/skills/v2/service.rs
@@ -729,6 +729,17 @@ impl Service {
         self.overview_with_target_refresh(false)
     }
 
+    pub fn refresh_agent_skill_view(
+        &self,
+        agent_id: &str,
+    ) -> Result<AgentSkillViewSnapshot, String> {
+        Ok(AgentSkillViewSnapshot {
+            agent_detail: self.get_agent_detail(agent_id)?,
+            overview: self.overview()?,
+            unmanaged: self.list_unmanaged()?,
+        })
+    }
+
     pub fn skill_pack_picker_data(&self) -> Result<SkillPackPickerData, String> {
         self.init_if_needed()?;
         let agents = self
@@ -2431,18 +2442,17 @@ impl Service {
     }
 
     pub fn delete_skill_target_distribution(&self, target_id: &str) -> Result<(), String> {
-        let agent_id = self.db.with_conn(|c| {
+        let exists = self.db.with_conn(|c| {
             c.query_row(
-                "SELECT agent_id FROM skill_targets WHERE id = ?1",
+                "SELECT 1 FROM skill_targets WHERE id = ?1",
                 params![target_id],
-                |r| r.get::<_, String>(0),
+                |_| Ok(()),
             )
             .optional()
             .map_err(|e| e.to_string())
         })?;
-        let agent_id = agent_id.ok_or_else(|| format!("Target not found: {target_id}"))?;
+        exists.ok_or_else(|| format!("Target not found: {target_id}"))?;
         self.remove_target_completely(target_id)?;
-        self.scan_one_agent_into_db(&agent_id)?;
         self.refresh_snapshot_best_effort();
         Ok(())
     }
@@ -2453,19 +2463,18 @@ impl Service {
     ) -> Result<DeleteSkillTargetDistributionsResult, String> {
         let mut deleted = 0usize;
         let mut failures = Vec::new();
-        let mut affected_agents = BTreeSet::new();
 
         for target_id in target_ids {
-            let agent_id = self.db.with_conn(|c| {
+            let exists = self.db.with_conn(|c| {
                 c.query_row(
-                    "SELECT agent_id FROM skill_targets WHERE id = ?1",
+                    "SELECT 1 FROM skill_targets WHERE id = ?1",
                     params![target_id],
-                    |r| r.get::<_, String>(0),
+                    |_| Ok(()),
                 )
                 .optional()
                 .map_err(|e| e.to_string())
             })?;
-            let Some(agent_id) = agent_id else {
+            if exists.is_none() {
                 failures.push(DeleteSkillTargetDistributionFailure {
                     target_id,
                     error: "Target not found".to_string(),
@@ -2475,7 +2484,6 @@ impl Service {
             match self.remove_target_completely(&target_id) {
                 Ok(()) => {
                     deleted += 1;
-                    affected_agents.insert(agent_id);
                 }
                 Err(error) => {
                     failures.push(DeleteSkillTargetDistributionFailure { target_id, error })
@@ -2483,10 +2491,9 @@ impl Service {
             }
         }
 
-        for agent_id in affected_agents {
-            self.scan_one_agent_into_db(&agent_id)?;
+        if deleted > 0 {
+            self.refresh_snapshot_best_effort();
         }
-        self.refresh_snapshot_best_effort();
         Ok(DeleteSkillTargetDistributionsResult { deleted, failures })
     }
 
@@ -2501,8 +2508,8 @@ impl Service {
             .optional()
             .map_err(|e| e.to_string())
         })?;
-        if let Some((agent_id, target_path)) = target {
-            let target_path = Path::new(&target_path);
+        if let Some((agent_id, target_path)) = target.as_ref() {
+            let target_path = Path::new(target_path);
             if agent_id == SHARED_SKILLS_AGENT_ID
                 && !shared_skill_mutation_path_allowed(
                     &self.home.join(".agents").join("skills"),
@@ -2516,13 +2523,21 @@ impl Service {
             }
             fsutil::remove_path(target_path)?;
         }
-        self.db.with_conn(|c| {
-            c.execute(
-                "DELETE FROM skill_targets WHERE id = ?1",
-                params![target_id],
-            )
-            .map_err(|e| e.to_string())
-        })?;
+        if let Some((agent_id, target_path)) = target.as_ref() {
+            self.db.transaction(|tx| {
+                tx.execute(
+                    "DELETE FROM unmanaged_items WHERE agent_id = ?1 AND path = ?2",
+                    params![agent_id, target_path],
+                )
+                .map_err(|e| e.to_string())?;
+                tx.execute(
+                    "DELETE FROM skill_targets WHERE id = ?1",
+                    params![target_id],
+                )
+                .map_err(|e| e.to_string())?;
+                Ok(())
+            })?;
+        }
         Ok(())
     }
 
@@ -3688,8 +3703,6 @@ impl Service {
         unmanaged_id: &str,
     ) -> Result<(), String> {
         self.remove_unmanaged_agent_skill(agent_id, unmanaged_id)?;
-        self.scan_one_agent_into_db(agent_id)?;
-        self.refresh_snapshot_best_effort();
         Ok(())
     }
 
@@ -3708,12 +3721,6 @@ impl Service {
                     error,
                 }),
             }
-        }
-        if deleted > 0 && failures.is_empty() {
-            self.scan_one_agent_into_db(agent_id)?;
-        }
-        if deleted > 0 {
-            self.refresh_snapshot_best_effort();
         }
         Ok(DeleteUnmanagedAgentSkillsResult { deleted, failures })
     }

--- a/src-tauri/src/skills/v2/tests.rs
+++ b/src-tauri/src/skills/v2/tests.rs
@@ -9,7 +9,7 @@ use rusqlite::params;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 /// Reuse the shared HOME lock from `skills` so v2 tests serialize against the
 /// legacy skill tests and `cargo test` is deterministic under parallelism.
@@ -2561,6 +2561,85 @@ fn delete_skill_target_distribution_removes_copy_and_db_target() {
 }
 
 #[test]
+fn delete_skill_target_distribution_cleans_only_matching_stale_inventory() {
+    let (_home, svc, _lock) = fresh_service("delete-target-incremental-inventory");
+    let src = write_skill(&svc.home.join("s"), "rev", "incremental-delete", Some("v1"));
+    svc.execute_add_center_skill(
+        AddCenterSkillInput {
+            source_path: src.display().to_string(),
+            source_type: "local_folder".to_string(),
+            source_uri: None,
+            imported_from_agent: None,
+            imported_from_path: None,
+            multi: None,
+            import_mode: None,
+        },
+        vec![],
+    )
+    .unwrap();
+    let preview = svc
+        .preview_distribute_skill(
+            vec!["incremental-delete".to_string()],
+            vec!["codex".to_string()],
+            "copy".to_string(),
+        )
+        .unwrap();
+    svc.execute_distribute_skill(preview, ClaimOrigin::Direct)
+        .unwrap();
+    let target = svc.get_skill_detail("incremental-delete").unwrap().targets[0].clone();
+    let unrelated_path = svc.home.join(".codex/skills/unrelated-stale");
+    svc.db()
+        .with_conn(|connection| {
+            for (id, path) in [
+                ("unm-matching-stale", target.target_path.clone()),
+                ("unm-unrelated-stale", unrelated_path.display().to_string()),
+            ] {
+                connection
+                    .execute(
+                        "INSERT INTO unmanaged_items(id, item_type, agent_id, path, inferred_skill_id, hash, reason, first_seen_at, last_seen_at)
+                         VALUES (?1, 'skill', 'codex', ?2, 'stale', NULL, 'not_in_center_library', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')",
+                        params![id, path],
+                    )
+                    .map_err(|error| error.to_string())?;
+            }
+            Ok(())
+        })
+        .unwrap();
+
+    svc.delete_skill_target_distribution(&target.id).unwrap();
+
+    let remaining = svc.list_unmanaged().unwrap();
+    assert!(remaining.iter().all(|item| item.id != "unm-matching-stale"));
+    assert!(remaining
+        .iter()
+        .any(|item| item.id == "unm-unrelated-stale"));
+}
+
+#[test]
+fn refresh_agent_skill_view_reads_consistent_db_snapshot() {
+    let (_home, svc, _lock) = fresh_service("agent-skill-view-snapshot");
+    let unmanaged_path = write_skill(
+        &svc.home.join(".codex/skills"),
+        "view-unmanaged",
+        "view-unmanaged",
+        Some("v1"),
+    );
+    svc.refresh().unwrap();
+
+    let snapshot = svc.refresh_agent_skill_view("codex").unwrap();
+
+    assert_eq!(snapshot.agent_detail.id, "codex");
+    assert_eq!(
+        snapshot.overview.metrics.unmanaged_count,
+        snapshot.unmanaged.len()
+    );
+    assert!(snapshot
+        .unmanaged
+        .iter()
+        .any(|item| item.path == unmanaged_path.display().to_string()));
+}
+
+#[test]
 fn delete_skill_target_distributions_removes_multiple_targets() {
     let (_home, svc, _lock) = fresh_service("delete-target-distributions");
     let src_one = write_skill(
@@ -3075,6 +3154,50 @@ fn delete_unmanaged_agent_skill_removes_local_copy_without_importing_center() {
         .unwrap()
         .iter()
         .all(|u| u.id != unmanaged.id));
+}
+
+#[test]
+fn delete_unmanaged_agent_skill_does_not_rewrite_recovery_snapshot() {
+    let (_home, svc, _lock) = fresh_service("delete-unmanaged-keeps-snapshot");
+    let rogue = write_skill(
+        &svc.home.join(".workbuddy/skills"),
+        "rogue",
+        "rogue-skill",
+        Some("v1"),
+    );
+    svc.refresh().unwrap();
+    let unmanaged = svc
+        .list_unmanaged()
+        .unwrap()
+        .into_iter()
+        .find(|item| item.path == rogue.display().to_string())
+        .unwrap();
+    let snapshot_path = PathBuf::from(crate::skills::v2::snapshot::export_to_file(&svc).unwrap());
+    let before = fs::metadata(&snapshot_path).unwrap().modified().unwrap();
+    std::thread::sleep(Duration::from_millis(20));
+
+    svc.delete_unmanaged_agent_skill("workbuddy", &unmanaged.id)
+        .unwrap();
+
+    let after = fs::metadata(&snapshot_path).unwrap().modified().unwrap();
+    assert_eq!(after, before);
+}
+
+#[test]
+fn delete_skill_target_distributions_with_no_success_does_not_rewrite_snapshot() {
+    let (_home, svc, _lock) = fresh_service("delete-target-zero-keeps-snapshot");
+    let snapshot_path = PathBuf::from(crate::skills::v2::snapshot::export_to_file(&svc).unwrap());
+    let before = fs::metadata(&snapshot_path).unwrap().modified().unwrap();
+    std::thread::sleep(Duration::from_millis(20));
+
+    let result = svc
+        .delete_skill_target_distributions(vec!["missing-target".to_string()])
+        .unwrap();
+
+    assert_eq!(result.deleted, 0);
+    assert_eq!(result.failures.len(), 1);
+    let after = fs::metadata(&snapshot_path).unwrap().modified().unwrap();
+    assert_eq!(after, before);
 }
 
 #[test]

--- a/src/components/skills-v2/AgentManagementPage.tsx
+++ b/src/components/skills-v2/AgentManagementPage.tsx
@@ -1579,6 +1579,7 @@ function SkillsTab({
   const [moveToPackTarget, setMoveToPackTarget] = useState<AgentDetail['skills'][number] | null>(null)
   const [deleteUnmanagedTarget, setDeleteUnmanagedTarget] = useState<UnmanagedItemDto | null>(null)
   const [deleteUnmanagedError, setDeleteUnmanagedError] = useState<string | null>(null)
+  const reconciliationGenerationRef = useRef(0)
   const [confirmingPackApply, setConfirmingPackApply] = useState(false)
   const [packApplyProgress, setPackApplyProgress] = useState<PackApplyProgress | null>(null)
   const [localNotice, setLocalNotice] = useState<string | null>(null)
@@ -1651,12 +1652,14 @@ function SkillsTab({
   const unmanagedDeleting = deletingUnmanagedIds.size > 0
   const unmanagedAdopting = adoptingIds.size > 0
   const actionBusy = busy || managedDeleting || unmanagedDeleting || unmanagedAdopting
+  const collectionBusy = busy || unmanagedAdopting
   const moveToPackOptions = useMemo(
     () => packOptionsForMove(detail, state.packs),
     [detail, state.packs],
   )
 
   useEffect(() => {
+    reconciliationGenerationRef.current += 1
     setManagedSelectionMode(false)
     setUnmanagedSelectionMode(false)
     setSelectedManagedIds(new Set())
@@ -1704,6 +1707,33 @@ function SkillsTab({
     await state.loadOverview(true)
   }
 
+  const reconcileDeletedAgentSkills = (agentId: string, runtimeEnvironmentId: string) => {
+    const generation = reconciliationGenerationRef.current + 1
+    reconciliationGenerationRef.current = generation
+    void (async () => {
+      let lastError: unknown = null
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        try {
+          const snapshot = await skillApiV2.refreshAgentSkillView(agentId)
+          if (reconciliationGenerationRef.current !== generation) return
+          useSkillStoreV2.getState().applyAgentSkillViewSnapshot(runtimeEnvironmentId, agentId, snapshot)
+          return
+        } catch (error) {
+          lastError = error
+        }
+      }
+      if (
+        reconciliationGenerationRef.current === generation
+        && useSkillStoreV2.getState().runtimeEnvironmentId === runtimeEnvironmentId
+        && useSkillStoreV2.getState().selectedAgentId === agentId
+      ) {
+        state.setError(t('skills.agentManagement.deleteRefreshFailed', {
+          error: skillErrorMessage(t, lastError),
+        }))
+      }
+    })()
+  }
+
   const syncAdoptedSkillsToPack = async (selection: BatchAdoptPackSelection, skillIds: string[]) => {
     const uniqueSkillIds = uniqueValues(skillIds)
     if (selection.kind === 'none' || uniqueSkillIds.length === 0) return null
@@ -1737,7 +1767,9 @@ function SkillsTab({
   const deleteManaged = async (targets: AgentDetail['skills']) => {
     if (targets.length === 0) return
     const ids = targets.map((target) => target.id)
-    setDeletingIds(new Set(ids))
+    const runtimeEnvironmentId = state.runtimeEnvironmentId
+    const agentId = detail.id
+    setDeletingIds((current) => new Set([...current, ...ids]))
     setLocalNotice(`正在删除 ${targets.length} 个 Skill 分发...`)
     state.setError(null)
     try {
@@ -1745,16 +1777,24 @@ function SkillsTab({
       const result = await skillApiV2.deleteSkillTargetDistributions(ids)
       const failed = result.failures.map((failure) => `${targetNames.get(failure.targetId) || failure.targetId}: ${failure.error}`)
       const failedIds = new Set(result.failures.map((failure) => failure.targetId))
-      await refreshAgentSkills()
+      const deletedIds = ids.filter((id) => !failedIds.has(id))
+      useSkillStoreV2.getState().removeAgentSkillItems(runtimeEnvironmentId, agentId, deletedIds, [])
       setSelectedManagedIds(failedIds)
       setManagedSelectionMode(failedIds.size > 0)
       setLocalNotice(`已删除 ${result.deleted} 个 Skill 分发${failed.length ? `，${failed.length} 个失败` : ''}`)
       if (failed.length === 0) state.setError(null)
       if (failed.length > 0) state.setError(failed.slice(0, 3).join('\n'))
+      if (deletedIds.length > 0) reconcileDeletedAgentSkills(agentId, runtimeEnvironmentId)
     } catch (e) {
-      state.setError(String(e))
+      if (useSkillStoreV2.getState().runtimeEnvironmentId === runtimeEnvironmentId) {
+        state.setError(String(e))
+      }
     } finally {
-      setDeletingIds(new Set())
+      setDeletingIds((current) => {
+        const next = new Set(current)
+        ids.forEach((id) => next.delete(id))
+        return next
+      })
     }
   }
 
@@ -1869,38 +1909,20 @@ function SkillsTab({
 
   const deleteUnmanaged = async (items: UnmanagedItemDto[]) => {
     if (items.length === 0) return false
+    const runtimeEnvironmentId = state.runtimeEnvironmentId
+    const agentId = detail.id
     const itemNames = new Map(items.map((item) => [item.id, item.inferredSkillId || pathBasename(item.path) || item.id]))
     const itemIds = new Set(items.map((item) => item.id))
-    setDeletingUnmanagedIds(itemIds)
+    setDeletingUnmanagedIds((current) => new Set([...current, ...itemIds]))
     setDeleteUnmanagedError(null)
     setLocalNotice(items.length === 1
       ? t('skills.agentManagement.unmanagedDelete.deleting', { name: itemNames.get(items[0].id) })
       : `正在删除 ${items.length} 个未管理 Skill...`)
     state.setError(null)
 
-    if (items.length === 1) {
-      const item = items[0]
-      try {
-        await skillApiV2.deleteUnmanagedAgentSkill(adoptOwnerAgentId(detail.id, item), item.id)
-        await refreshAgentSkills()
-        setSelectedUnmanagedIds((current) => {
-          const next = new Set(current)
-          next.delete(item.id)
-          return next
-        })
-        setLocalNotice(t('skills.agentManagement.unmanagedDelete.deleted', { name: itemNames.get(item.id) }))
-        state.setError(null)
-        return true
-      } catch (e) {
-        setDeleteUnmanagedError(skillErrorMessage(t, e))
-        return false
-      } finally {
-        setDeletingUnmanagedIds(new Set())
-      }
-    }
-
     const deletedIds = new Set<string>()
     const failed: string[] = []
+    const failedIds = new Set<string>()
     const itemsByOwner = new Map<string, UnmanagedItemDto[]>()
     items.forEach((item) => {
       const owner = adoptOwnerAgentId(detail.id, item)
@@ -1909,30 +1931,32 @@ function SkillsTab({
     for (const [owner, ownerItems] of itemsByOwner) {
       try {
         const result = await skillApiV2.deleteUnmanagedAgentSkills(owner, ownerItems.map((item) => item.id))
-        const failedIds = new Set(result.failures.map((failure) => failure.unmanagedId))
+        const ownerFailedIds = new Set(result.failures.map((failure) => failure.unmanagedId))
         ownerItems.forEach((item) => {
-          if (!failedIds.has(item.id)) deletedIds.add(item.id)
+          if (ownerFailedIds.has(item.id)) failedIds.add(item.id)
+          else deletedIds.add(item.id)
         })
-        failed.push(...result.failures.map((failure) => `${itemNames.get(failure.unmanagedId) || failure.unmanagedId}: ${failure.error}`))
+        failed.push(...result.failures.map((failure) => `${itemNames.get(failure.unmanagedId) || failure.unmanagedId}: ${skillErrorMessage(t, failure.error)}`))
       } catch (e) {
         failed.push(`${owner}: ${skillErrorMessage(t, e)}`)
+        ownerItems.forEach((item) => failedIds.add(item.id))
       }
     }
-    try {
-      await refreshAgentSkills()
-    } catch (e) {
-      failed.push(`刷新列表: ${skillErrorMessage(t, e)}`)
-    }
-    setSelectedUnmanagedIds((current) => {
-      const next = new Set(current)
-      deletedIds.forEach((id) => next.delete(id))
-      return next
-    })
+    useSkillStoreV2.getState().removeAgentSkillItems(runtimeEnvironmentId, agentId, [], [...deletedIds])
+    setSelectedUnmanagedIds(failedIds)
     if (failed.length === 0) setUnmanagedSelectionMode(false)
-    setLocalNotice(`已删除 ${deletedIds.size} 个未管理 Skill${failed.length ? `，${failed.length} 个失败` : ''}`)
+    setUnmanagedSelectionMode(failedIds.size > 0)
+    setLocalNotice(items.length === 1 && deletedIds.size === 1
+      ? t('skills.agentManagement.unmanagedDelete.deleted', { name: itemNames.get(items[0].id) })
+      : `已删除 ${deletedIds.size} 个未管理 Skill${failed.length ? `，${failed.length} 个失败` : ''}`)
     if (failed.length === 0) state.setError(null)
     if (failed.length > 0) state.setError(failed.slice(0, 3).join('\n'))
-    setDeletingUnmanagedIds(new Set())
+    if (deletedIds.size > 0) reconcileDeletedAgentSkills(agentId, runtimeEnvironmentId)
+    setDeletingUnmanagedIds((current) => {
+      const next = new Set(current)
+      itemIds.forEach((id) => next.delete(id))
+      return next
+    })
     return deletedIds.size === items.length
   }
 
@@ -1951,8 +1975,9 @@ function SkillsTab({
   const deletingSingleSharedUnmanaged = deleteUnmanagedTarget ? isSharedAgentsUnmanaged(deleteUnmanagedTarget) : false
   const confirmBatchDelete = async () => {
     if (!batchDeleteTargets || batchDeleteTargets.length === 0) return
-    await deleteManaged(batchDeleteTargets)
+    const targets = batchDeleteTargets
     setBatchDeleteTargets(null)
+    await deleteManaged(targets)
   }
   const applyPackFromRail = async (packId: string, agentId: string) => {
     const pack = detail.availablePacks.find((item) => item.id === packId)
@@ -2170,7 +2195,7 @@ function SkillsTab({
             selectable={managedSelectionMode}
             selectedIds={selectedManagedIds}
             deletingIds={deletingIds}
-            busy={actionBusy}
+            busy={collectionBusy}
             emptyMessage={source === 'shared'
               ? t('skills.agentManagement.inheritedManagedNoResults')
               : q || packFilter !== 'all'
@@ -2215,7 +2240,7 @@ function SkillsTab({
                 skills={shownUnmanaged}
                 mode={viewMode}
                 agentId={source === 'shared' ? SHARED_SKILLS_AGENT_ID : detail.id}
-                busy={actionBusy}
+                busy={collectionBusy}
                 selectable={unmanagedSelectionMode}
                 selectedIds={selectedUnmanagedIds}
                 adoptingIds={adoptingIds}
@@ -2257,7 +2282,7 @@ function SkillsTab({
                 skills={shownReadOnly}
                 mode={viewMode}
                 agentId={detail.id}
-                busy={actionBusy}
+                busy={collectionBusy}
                 selectable={false}
                 selectedIds={new Set<string>()}
                 adoptingIds={adoptingIds}
@@ -2359,8 +2384,8 @@ function SkillsTab({
           onCancel={() => setBatchDeleteUnmanagedTargets(null)}
           onConfirm={async () => {
             const items = batchDeleteUnmanagedTargets
-            await deleteUnmanaged(items)
             setBatchDeleteUnmanagedTargets(null)
+            await deleteUnmanaged(items)
           }}
         >
           {deletingSharedUnmanaged ? (
@@ -2412,11 +2437,10 @@ function SkillsTab({
             setDeleteUnmanagedTarget(null)
           }}
           onConfirm={async () => {
-            const ok = await deleteUnmanaged([deleteUnmanagedTarget])
-            if (ok) {
-              setDeleteUnmanagedError(null)
-              setDeleteUnmanagedTarget(null)
-            }
+            const item = deleteUnmanagedTarget
+            setDeleteUnmanagedError(null)
+            setDeleteUnmanagedTarget(null)
+            await deleteUnmanaged([item])
           }}
         >
           <p>{deletingSingleSharedUnmanaged

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1159,6 +1159,7 @@
       "scanCompleteShared": "Scan complete: this Agent has {{managed}} managed and {{unmanaged}} unmanaged; the .agents shared directory has {{sharedManaged}} managed and {{sharedUnmanaged}} unmanaged",
       "scanCompleteSharedReadOnly": "Scan complete: this Agent has {{managed}} managed, {{unmanaged}} unmanaged, and {{readOnly}} built-in read-only; the .agents shared directory has {{sharedManaged}} managed, {{sharedUnmanaged}} unmanaged, and {{sharedReadOnly}} read-only",
       "scanCompleteReadOnly": "Scan complete: {{managed}} managed, {{unmanaged}} unmanaged, {{readOnly}} built-in read-only",
+      "deleteRefreshFailed": "Deletion completed, but the list could not be refreshed: {{error}}. Refresh the overview or rescan this Agent.",
       "sharedDirectoryNotice": "{{count}} Skills are from the .agents shared directory. After adoption, they will be moved into the center library and removed from the shared directory. Manage future distribution through the center library or skill packs.",
       "pathSettings": {
         "tab": "Paths & settings",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -1160,6 +1160,7 @@
       "scanCompleteShared": "スキャン完了：この Agent は管理済み {{managed}}、未管理 {{unmanaged}}；.agents 共有ディレクトリは管理済み {{sharedManaged}}、未管理 {{sharedUnmanaged}}",
       "scanCompleteSharedReadOnly": "スキャン完了：この Agent は管理済み {{managed}}、未管理 {{unmanaged}}、組み込み読み取り専用 {{readOnly}}；.agents 共有ディレクトリは管理済み {{sharedManaged}}、未管理 {{sharedUnmanaged}}、読み取り専用 {{sharedReadOnly}}",
       "scanCompleteReadOnly": "スキャン完了：管理済み {{managed}}、未管理 {{unmanaged}}、組み込み読み取り専用 {{readOnly}}",
+      "deleteRefreshFailed": "削除は完了しましたが、一覧を更新できませんでした：{{error}}。概要を更新するか、この Agent を再スキャンしてください。",
       "sharedDirectoryNotice": "{{count}} 個の Skill は .agents 共有ディレクトリにあります。引き継ぎ後はセンターライブラリに移動し、共有ディレクトリから削除されます。以後はセンターライブラリまたはスキルパックから配布を管理してください。",
       "pathSettings": {
         "tab": "パスと設定",

--- a/src/i18n/locales/ko.json
+++ b/src/i18n/locales/ko.json
@@ -1160,6 +1160,7 @@
       "scanCompleteShared": "스캔 완료: 이 Agent는 관리됨 {{managed}}, 관리되지 않음 {{unmanaged}}; .agents 공유 디렉터리는 관리됨 {{sharedManaged}}, 관리되지 않음 {{sharedUnmanaged}}",
       "scanCompleteSharedReadOnly": "스캔 완료: 이 Agent는 관리됨 {{managed}}, 관리되지 않음 {{unmanaged}}, 기본 제공 읽기 전용 {{readOnly}}; .agents 공유 디렉터리는 관리됨 {{sharedManaged}}, 관리되지 않음 {{sharedUnmanaged}}, 읽기 전용 {{sharedReadOnly}}",
       "scanCompleteReadOnly": "스캔 완료: 관리됨 {{managed}}, 관리되지 않음 {{unmanaged}}, 기본 제공 읽기 전용 {{readOnly}}",
+      "deleteRefreshFailed": "삭제는 완료되었지만 목록을 새로 고치지 못했습니다: {{error}}. 개요를 새로 고치거나 이 Agent를 다시 스캔하세요.",
       "sharedDirectoryNotice": "{{count}}개의 Skill이 .agents 공유 디렉터리에 있습니다. 인계 후 중앙 라이브러리로 이동되고 공유 디렉터리에서는 제거됩니다. 이후 배포는 중앙 라이브러리 또는 스킬 팩에서 관리하세요.",
       "pathSettings": {
         "tab": "경로 및 설정",

--- a/src/i18n/locales/tr.json
+++ b/src/i18n/locales/tr.json
@@ -1008,6 +1008,7 @@
       "scanCompleteShared": "Tarama tamamlandı: bu Agent için {{managed}} yönetilen ve {{unmanaged}} yönetilmeyen; .agents paylaşılan dizininde {{sharedManaged}} yönetilen ve {{sharedUnmanaged}} yönetilmeyen",
       "scanCompleteSharedReadOnly": "Tarama tamamlandı: bu Agent için {{managed}} yönetilen, {{unmanaged}} yönetilmeyen ve {{readOnly}} yerleşik salt okunur; .agents paylaşılan dizininde {{sharedManaged}} yönetilen, {{sharedUnmanaged}} yönetilmeyen ve {{sharedReadOnly}} salt okunur",
       "scanCompleteReadOnly": "Tarama tamamlandı: {{managed}} yönetilen, {{unmanaged}} yönetilmeyen, {{readOnly}} yerleşik salt okunur",
+      "deleteRefreshFailed": "Silme tamamlandı ancak liste yenilenemedi: {{error}}. Genel bakışı yenileyin veya bu Agent'ı yeniden tarayın.",
       "sharedDirectoryNotice": "{{count}} Skill .agents paylaşılan dizininden geliyor. Devralındıktan sonra merkez kütüphaneye taşınır ve paylaşılan dizinden kaldırılır. Sonraki dağıtımları merkez kütüphane veya Skill paketleri üzerinden yönetin.",
       "pathSettings": {
         "tab": "Yollar ve ayarlar",

--- a/src/i18n/locales/zh.json
+++ b/src/i18n/locales/zh.json
@@ -1200,6 +1200,7 @@
       "scanCompleteShared": "扫描完成：此 Agent 已管理 {{managed}}，未管理 {{unmanaged}}；.agents 共享目录已管理 {{sharedManaged}}，未管理 {{sharedUnmanaged}}",
       "scanCompleteSharedReadOnly": "扫描完成：此 Agent 已管理 {{managed}}，未管理 {{unmanaged}}，内置只读 {{readOnly}}；.agents 共享目录已管理 {{sharedManaged}}，未管理 {{sharedUnmanaged}}，只读 {{sharedReadOnly}}",
       "scanCompleteReadOnly": "扫描完成：已管理 {{managed}}，未管理 {{unmanaged}}，内置只读 {{readOnly}}",
+      "deleteRefreshFailed": "删除已完成，但列表刷新失败：{{error}}。可手动刷新总览或重新扫描此 Agent。",
       "sharedDirectoryNotice": "{{count}} 个 Skill 来自 .agents 共享目录。接管后会进入中心库，并从共享目录清理；后续请通过中心库或技能包控制分发。",
       "pathSettings": {
         "tab": "路径与设置",

--- a/src/services/skillApiV2.ts
+++ b/src/services/skillApiV2.ts
@@ -444,6 +444,12 @@ export interface SkillManagerOverview {
   settings: SkillManagerSettings
 }
 
+export interface AgentSkillViewSnapshot {
+  agentDetail: AgentDetail
+  overview: SkillManagerOverview
+  unmanaged: UnmanagedItemDto[]
+}
+
 export interface SkillPackPickerData {
   agents: AgentSummary[]
   packs: SkillPackSummary[]
@@ -1314,6 +1320,14 @@ export const skillApiV2 = {
   listAgents: () => (isTauriRuntime() ? invoke<AgentSummary[]>('list_managed_agents_v2') : Promise.resolve([])),
   getAgentDetail: (agentId: string) =>
     isTauriRuntime() ? invoke<AgentDetail>('get_agent_detail_v2', { agentId }) : Promise.resolve(null as unknown as AgentDetail),
+  refreshAgentSkillView: (agentId: string) =>
+    isTauriRuntime()
+      ? invoke<AgentSkillViewSnapshot>('refresh_agent_skill_view_v2', { agentId })
+      : Promise.all([
+          skillApiV2.getAgentDetail(agentId),
+          skillApiV2.overview(),
+          skillApiV2.listUnmanaged(),
+        ]).then(([agentDetail, overview, unmanaged]) => ({ agentDetail, overview, unmanaged })),
   readAgentConfigFile: (agentId: string, path: string) =>
     isTauriRuntime()
       ? invoke<AgentConfigDocument>('read_agent_config_file_v2', { agentId, path })

--- a/src/stores/skillStoreV2.ts
+++ b/src/stores/skillStoreV2.ts
@@ -6,6 +6,7 @@ import type {
   SkillDetail,
   AgentSummary,
   AgentDetail,
+  AgentSkillViewSnapshot,
   SkillPackSummary,
   SkillPackDetail,
   DiagnosisIssue,
@@ -108,6 +109,8 @@ interface SkillV2Actions {
   selectPack: (id: string | null) => Promise<void>
   selectAgent: (id: string | null) => Promise<void>
   loadAgentDetail: (agentId: string, force?: boolean) => Promise<void>
+  applyAgentSkillViewSnapshot: (expectedRuntimeEnvironmentId: string, agentId: string, snapshot: AgentSkillViewSnapshot) => boolean
+  removeAgentSkillItems: (expectedRuntimeEnvironmentId: string, agentId: string, managedTargetIds: string[], unmanagedIds: string[]) => boolean
   loadProjects: (force?: boolean) => Promise<void>
   addProject: (rootPath: string) => Promise<void>
   removeProject: (projectId: string) => Promise<void>
@@ -369,6 +372,98 @@ export const useSkillStoreV2 = create<SkillV2State & SkillV2Actions>((set, get) 
         set({ agentDetailLoading: false })
       }
     }
+  },
+  applyAgentSkillViewSnapshot: (expectedRuntimeEnvironmentId, agentId, snapshot) => {
+    if (
+      get().runtimeEnvironmentId !== expectedRuntimeEnvironmentId
+      || get().selectedAgentId !== agentId
+      || snapshot.agentDetail.id !== agentId
+    ) {
+      return false
+    }
+    const overview = snapshot.overview
+    set({
+      selectedAgentDetail: snapshot.agentDetail,
+      agentDetailLoading: false,
+      overview,
+      skills: overview.skills,
+      agents: overview.agents,
+      packs: overview.packs,
+      issues: overview.issues,
+      unmanaged: snapshot.unmanaged,
+      settings: overview.settings,
+      lastOverviewLoadedAt: Date.now(),
+      initialized: true,
+    })
+    return true
+  },
+  removeAgentSkillItems: (expectedRuntimeEnvironmentId, agentId, managedTargetIds, unmanagedIds) => {
+    const current = get()
+    const detail = current.selectedAgentDetail
+    if (
+      current.runtimeEnvironmentId !== expectedRuntimeEnvironmentId
+      || current.selectedAgentId !== agentId
+      || detail?.id !== agentId
+    ) {
+      return false
+    }
+
+    const managedIds = new Set(managedTargetIds)
+    const unmanagedIdSet = new Set(unmanagedIds)
+    const managedTargets = [...detail.skills, ...detail.inheritedManagedSkills]
+      .filter((target) => managedIds.has(target.id))
+    const unmanagedItems = [...current.unmanaged, ...detail.inheritedUnmanagedSkills]
+      .filter((item, index, items) => unmanagedIdSet.has(item.id) && items.findIndex((candidate) => candidate.id === item.id) === index)
+    const removedTargetKeys = new Set(managedTargets.map((target) => `${target.skillId}\0${target.agentId}`))
+    const managedCounts = new Map<string, number>()
+    const unmanagedCounts = new Map<string, number>()
+    managedTargets.forEach((target) => managedCounts.set(target.agentId, (managedCounts.get(target.agentId) || 0) + 1))
+    unmanagedItems.forEach((item) => {
+      if (item.agentId) unmanagedCounts.set(item.agentId, (unmanagedCounts.get(item.agentId) || 0) + 1)
+    })
+
+    const overview = current.overview
+      ? {
+          ...current.overview,
+          metrics: {
+            ...current.overview.metrics,
+            targetCount: Math.max(0, current.overview.metrics.targetCount - managedTargets.length),
+            unmanagedCount: Math.max(0, current.overview.metrics.unmanagedCount - unmanagedItems.length),
+          },
+          skills: current.overview.skills.map((skill) => ({
+            ...skill,
+            installedAgents: skill.installedAgents.filter((installed) => !removedTargetKeys.has(`${skill.id}\0${installed.agentId}`)),
+          })),
+          agents: current.overview.agents.map((agent) => ({
+            ...agent,
+            managedSkillCount: Math.max(0, agent.managedSkillCount - (managedCounts.get(agent.id) || 0)),
+            unmanagedSkillCount: Math.max(0, agent.unmanagedSkillCount - (unmanagedCounts.get(agent.id) || 0)),
+          })),
+        }
+      : null
+    const skills = overview?.skills ?? current.skills.map((skill) => ({
+      ...skill,
+      installedAgents: skill.installedAgents.filter((installed) => !removedTargetKeys.has(`${skill.id}\0${installed.agentId}`)),
+    }))
+    const agents = overview?.agents ?? current.agents.map((agent) => ({
+      ...agent,
+      managedSkillCount: Math.max(0, agent.managedSkillCount - (managedCounts.get(agent.id) || 0)),
+      unmanagedSkillCount: Math.max(0, agent.unmanagedSkillCount - (unmanagedCounts.get(agent.id) || 0)),
+    }))
+
+    set({
+      selectedAgentDetail: {
+        ...detail,
+        skills: detail.skills.filter((target) => !managedIds.has(target.id)),
+        inheritedManagedSkills: detail.inheritedManagedSkills.filter((target) => !managedIds.has(target.id)),
+        inheritedUnmanagedSkills: detail.inheritedUnmanagedSkills.filter((item) => !unmanagedIdSet.has(item.id)),
+      },
+      overview,
+      skills,
+      agents,
+      unmanaged: current.unmanaged.filter((item) => !unmanagedIdSet.has(item.id)),
+    })
+    return true
   },
   loadProjects: async () => {
     const runtimeEnvironmentId = get().runtimeEnvironmentId

--- a/src/test/skillManagerV2View.test.tsx
+++ b/src/test/skillManagerV2View.test.tsx
@@ -1285,6 +1285,7 @@ describe('Local skill import', () => {
 describe('Agent sync local agent chips', () => {
   beforeEach(() => {
     cleanup()
+    vi.restoreAllMocks()
   })
 
   it('shows a task-focused pending inbox by default and hides managed skills', async () => {

--- a/src/test/skillManagerV2View.test.tsx
+++ b/src/test/skillManagerV2View.test.tsx
@@ -2741,6 +2741,19 @@ describe('Skill detail slider + agent page render without crashing', () => {
       ],
       issues: [],
     })
+    vi.spyOn(skillApiV2, 'refreshAgentSkillView').mockImplementation(async (agentId) => {
+      const current = useSkillStoreV2.getState()
+      return {
+        agentDetail: current.selectedAgentDetail?.id === agentId ? current.selectedAgentDetail : agentDetail,
+        overview: {
+          ...makeOverview(),
+          skills: current.skills,
+          agents: current.agents,
+          packs: current.packs,
+        },
+        unmanaged: current.unmanaged,
+      }
+    })
   })
 
   it('SkillDetailSlider renders when open', async () => {
@@ -4706,14 +4719,18 @@ describe('Skill detail slider + agent page render without crashing', () => {
   it('deletes managed skills directly from the agent skill cards and in batches', async () => {
     const deleteTargets = vi.spyOn(skillApiV2, 'deleteSkillTargetDistributions').mockResolvedValue({ deleted: 1, failures: [] })
     deleteTargets.mockClear()
-    const loadAgentDetail = vi.spyOn(useSkillStoreV2.getState(), 'loadAgentDetail').mockResolvedValue(undefined)
-    const loadOverview = vi.spyOn(useSkillStoreV2.getState(), 'loadOverview').mockResolvedValue(undefined)
+    const refreshAgentSkillView = vi.mocked(skillApiV2.refreshAgentSkillView)
     const { AgentManagementPage } = await import('../components/skills-v2/AgentManagementPage')
     render(<AgentManagementPage />)
     fireEvent.click(screen.getByText('Skills (2)'))
 
     fireEvent.click(screen.getByRole('button', { name: '删除 release-checklist' }))
     await waitFor(() => expect(deleteTargets).toHaveBeenCalledWith(['target-1']))
+    await waitFor(() => expect(screen.queryByRole('button', { name: '删除 release-checklist' })).not.toBeInTheDocument())
+
+    act(() => {
+      useSkillStoreV2.setState({ selectedAgentDetail: agentDetail })
+    })
 
     fireEvent.click(screen.getByRole('button', { name: '批量选择' }))
     fireEvent.click(screen.getByLabelText('选择 release-checklist'))
@@ -4723,9 +4740,25 @@ describe('Skill detail slider + agent page render without crashing', () => {
     expect(deleteTargets).toHaveBeenCalledTimes(1)
 
     fireEvent.click(screen.getByRole('button', { name: '确认删除' }))
+    expect(screen.queryByRole('heading', { name: '确认批量删除 Skill？' })).not.toBeInTheDocument()
     await waitFor(() => expect(deleteTargets).toHaveBeenCalledTimes(2))
-    expect(loadAgentDetail).toHaveBeenCalledWith('claude-code', true)
-    expect(loadOverview).toHaveBeenCalledWith(true)
+    await waitFor(() => expect(refreshAgentSkillView).toHaveBeenCalledWith('claude-code'))
+  })
+
+  it('retries the composite Agent Skill refresh once without using the legacy list chain', async () => {
+    vi.spyOn(skillApiV2, 'deleteSkillTargetDistributions').mockResolvedValue({ deleted: 1, failures: [] })
+    const refreshAgentSkillView = vi.mocked(skillApiV2.refreshAgentSkillView)
+    refreshAgentSkillView.mockRejectedValueOnce(new Error('temporary refresh failure'))
+    const listUnmanaged = vi.spyOn(skillApiV2, 'listUnmanaged')
+    const { AgentManagementPage } = await import('../components/skills-v2/AgentManagementPage')
+    render(<AgentManagementPage />)
+    fireEvent.click(screen.getByText('Skills (2)'))
+
+    fireEvent.click(screen.getByRole('button', { name: '删除 release-checklist' }))
+
+    await waitFor(() => expect(refreshAgentSkillView).toHaveBeenCalledTimes(2))
+    expect(listUnmanaged).not.toHaveBeenCalled()
+    expect(useSkillStoreV2.getState().error).toBeNull()
   })
 
   it('cancels managed skill batch deletion from the confirmation dialog', async () => {
@@ -4760,10 +4793,10 @@ describe('Skill detail slider + agent page render without crashing', () => {
       agents: [makeSidebarAgent('codex', 'Codex')],
       unmanaged: [],
     })
-    const deleteTargets = vi.spyOn(skillApiV2, 'deleteSkillTargetDistributions').mockResolvedValue({ deleted: 1, failures: [] })
-    vi.spyOn(skillApiV2, 'listUnmanaged').mockResolvedValue([])
-    vi.spyOn(useSkillStoreV2.getState(), 'loadAgentDetail').mockResolvedValue(undefined)
-    vi.spyOn(useSkillStoreV2.getState(), 'loadOverview').mockResolvedValue(undefined)
+    let finishDelete: (() => void) | null = null
+    const deleteTargets = vi.spyOn(skillApiV2, 'deleteSkillTargetDistributions').mockImplementation(() => new Promise((resolve) => {
+      finishDelete = () => resolve({ deleted: 1, failures: [] })
+    }))
     const { AgentManagementPage } = await import('../components/skills-v2/AgentManagementPage')
     render(<AgentManagementPage />)
     fireEvent.click(screen.getByRole('button', { name: 'Skills (2)' }))
@@ -4777,7 +4810,12 @@ describe('Skill detail slider + agent page render without crashing', () => {
     expect(deleteTargets).not.toHaveBeenCalled()
     fireEvent.click(within(dialog).getByRole('button', { name: '从共享目录删除' }))
 
+    expect(screen.queryByRole('dialog', { name: '移除共享的已管理 Skill？' })).not.toBeInTheDocument()
     await waitFor(() => expect(deleteTargets).toHaveBeenCalledWith(['target-shared-review']))
+    expect(screen.getByRole('button', { name: '删除中 shared-review' })).toHaveAttribute('aria-busy', 'true')
+    expect(finishDelete).toBeTypeOf('function')
+    ;(finishDelete as unknown as () => void)()
+    await waitFor(() => expect(screen.queryByText('shared-review')).not.toBeInTheDocument())
   })
 
   it('batch deletes shared managed Skills through the standard selection controls', async () => {
@@ -4817,10 +4855,8 @@ describe('Skill detail slider + agent page render without crashing', () => {
   })
 
   it('deletes an unmanaged agent skill from the skill card after confirmation', async () => {
-    const deleteUnmanaged = vi.spyOn(skillApiV2, 'deleteUnmanagedAgentSkill').mockResolvedValue(undefined)
-    vi.spyOn(skillApiV2, 'listUnmanaged').mockResolvedValue([])
-    const loadAgentDetail = vi.spyOn(useSkillStoreV2.getState(), 'loadAgentDetail').mockResolvedValue(undefined)
-    const loadOverview = vi.spyOn(useSkillStoreV2.getState(), 'loadOverview').mockResolvedValue(undefined)
+    const deleteUnmanaged = vi.spyOn(skillApiV2, 'deleteUnmanagedAgentSkills').mockResolvedValue({ deleted: 1, failures: [] })
+    const refreshAgentSkillView = vi.mocked(skillApiV2.refreshAgentSkillView)
     const { AgentManagementPage } = await import('../components/skills-v2/AgentManagementPage')
     render(<AgentManagementPage />)
     fireEvent.click(screen.getByText('Skills (2)'))
@@ -4831,10 +4867,10 @@ describe('Skill detail slider + agent page render without crashing', () => {
     expect(dialog).toBeInTheDocument()
     expect(dialog).toHaveTextContent('/c/skills/manual-skill')
     fireEvent.click(screen.getByRole('button', { name: '直接删除' }))
+    expect(screen.queryByRole('dialog', { name: '删除 Skill「manual-skill」？' })).not.toBeInTheDocument()
 
-    await waitFor(() => expect(deleteUnmanaged).toHaveBeenCalledWith('claude-code', 'unmanaged-1'))
-    expect(loadAgentDetail).toHaveBeenCalledWith('claude-code', true)
-    expect(loadOverview).toHaveBeenCalledWith(true)
+    await waitFor(() => expect(deleteUnmanaged).toHaveBeenCalledWith('claude-code', ['unmanaged-1']))
+    await waitFor(() => expect(refreshAgentSkillView).toHaveBeenCalledWith('claude-code'))
   })
 
   it('permanently deletes a shared unmanaged Skill with owner agents after confirmation', async () => {
@@ -4852,10 +4888,7 @@ describe('Skill detail slider + agent page render without crashing', () => {
       agents: [makeSidebarAgent('codex', 'Codex')],
       unmanaged: [],
     })
-    const deleteUnmanaged = vi.spyOn(skillApiV2, 'deleteUnmanagedAgentSkill').mockResolvedValue(undefined)
-    vi.spyOn(skillApiV2, 'listUnmanaged').mockResolvedValue([])
-    vi.spyOn(useSkillStoreV2.getState(), 'loadAgentDetail').mockResolvedValue(undefined)
-    vi.spyOn(useSkillStoreV2.getState(), 'loadOverview').mockResolvedValue(undefined)
+    const deleteUnmanaged = vi.spyOn(skillApiV2, 'deleteUnmanagedAgentSkills').mockResolvedValue({ deleted: 1, failures: [] })
     const { AgentManagementPage } = await import('../components/skills-v2/AgentManagementPage')
     render(<AgentManagementPage />)
     fireEvent.click(screen.getByRole('button', { name: 'Skills (2)' }))
@@ -4869,11 +4902,12 @@ describe('Skill detail slider + agent page render without crashing', () => {
     expect(dialog).toHaveTextContent('不会复制到中心库')
     expect(deleteUnmanaged).not.toHaveBeenCalled()
     fireEvent.click(within(dialog).getByRole('button', { name: '从共享目录删除' }))
+    expect(screen.queryByRole('dialog', { name: '永久删除共享的未管理 Skill？' })).not.toBeInTheDocument()
 
-    await waitFor(() => expect(deleteUnmanaged).toHaveBeenCalledWith('agents', 'raw-shared-writing'))
+    await waitFor(() => expect(deleteUnmanaged).toHaveBeenCalledWith('agents', ['raw-shared-writing']))
   })
 
-  it('keeps unmanaged deletion errors visible inside the confirmation dialog', async () => {
+  it('closes the unmanaged confirmation dialog and keeps failed items visible', async () => {
     const codexItem = {
       id: 'unmanaged-codex-bird',
       agentId: 'codex',
@@ -4900,7 +4934,10 @@ describe('Skill detail slider + agent page render without crashing', () => {
     const mismatch = new Error(
       "Unmanaged item 'unmanaged-codex-bird' does not belong to agent 'codex'.",
     )
-    const deleteUnmanaged = vi.spyOn(skillApiV2, 'deleteUnmanagedAgentSkill').mockRejectedValue(mismatch)
+    const deleteUnmanaged = vi.spyOn(skillApiV2, 'deleteUnmanagedAgentSkills').mockResolvedValue({
+      deleted: 0,
+      failures: [{ unmanagedId: 'unmanaged-codex-bird', error: mismatch.message }],
+    })
     const { AgentManagementPage } = await import('../components/skills-v2/AgentManagementPage')
     render(<AgentManagementPage />)
     fireEvent.click(screen.getByText('Skills (2)'))
@@ -4911,9 +4948,10 @@ describe('Skill detail slider + agent page render without crashing', () => {
     expect(dialog).toHaveClass('sm2__modal--unmanaged-delete')
     fireEvent.click(within(dialog).getByRole('button', { name: '直接删除' }))
 
-    await waitFor(() => expect(deleteUnmanaged).toHaveBeenCalledWith('codex', 'unmanaged-codex-bird'))
-    expect(await within(dialog).findByText('该未管理 Skill 不属于 Agent「codex」，请重新扫描后重试。')).toBeInTheDocument()
-    expect(useSkillStoreV2.getState().error).toBeNull()
+    expect(screen.queryByRole('dialog', { name: '删除 Skill「bird」？' })).not.toBeInTheDocument()
+    await waitFor(() => expect(deleteUnmanaged).toHaveBeenCalledWith('codex', ['unmanaged-codex-bird']))
+    expect(await screen.findByText(/该未管理 Skill 不属于 Agent「codex」，请重新扫描后重试/)).toBeInTheDocument()
+    expect(useSkillStoreV2.getState().unmanaged).toContainEqual(codexItem)
   })
 
   it('deletes selected unmanaged agent skills in a batch after confirmation', async () => {
@@ -4932,9 +4970,7 @@ describe('Skill detail slider + agent page render without crashing', () => {
       ],
     })
     const deleteUnmanaged = vi.spyOn(skillApiV2, 'deleteUnmanagedAgentSkills').mockResolvedValue({ deleted: 2, failures: [] })
-    vi.spyOn(skillApiV2, 'listUnmanaged').mockResolvedValue([])
-    const loadAgentDetail = vi.spyOn(useSkillStoreV2.getState(), 'loadAgentDetail').mockResolvedValue(undefined)
-    const loadOverview = vi.spyOn(useSkillStoreV2.getState(), 'loadOverview').mockResolvedValue(undefined)
+    const refreshAgentSkillView = vi.mocked(skillApiV2.refreshAgentSkillView)
     const { AgentManagementPage } = await import('../components/skills-v2/AgentManagementPage')
     render(<AgentManagementPage />)
     fireEvent.click(screen.getByText('Skills (3)'))
@@ -4948,10 +4984,43 @@ describe('Skill detail slider + agent page render without crashing', () => {
     expect(deleteUnmanaged).not.toHaveBeenCalled()
 
     fireEvent.click(screen.getByRole('button', { name: '确认删除' }))
+    expect(screen.queryByRole('dialog', { name: '确认批量删除未管理 Skill？' })).not.toBeInTheDocument()
 
     await waitFor(() => expect(deleteUnmanaged).toHaveBeenCalledWith('claude-code', ['unmanaged-1', 'unmanaged-2']))
-    expect(loadAgentDetail).toHaveBeenCalledWith('claude-code', true)
-    expect(loadOverview).toHaveBeenCalledWith(true)
+    await waitFor(() => expect(refreshAgentSkillView).toHaveBeenCalledWith('claude-code'))
+  })
+
+  it('removes successful unmanaged batch items and keeps failed items selected', async () => {
+    const failedItem: UnmanagedItemDto = {
+      id: 'unmanaged-2',
+      agentId: 'claude-code',
+      itemType: 'skill',
+      path: '/c/skills/another-skill',
+      inferredSkillId: 'another-skill',
+      hash: null,
+      reason: 'not_in_center_library',
+    }
+    useSkillStoreV2.setState({
+      unmanaged: [...useSkillStoreV2.getState().unmanaged, failedItem],
+    })
+    vi.spyOn(skillApiV2, 'deleteUnmanagedAgentSkills').mockResolvedValue({
+      deleted: 1,
+      failures: [{ unmanagedId: failedItem.id, error: 'permission denied' }],
+    })
+    const { AgentManagementPage } = await import('../components/skills-v2/AgentManagementPage')
+    render(<AgentManagementPage />)
+    fireEvent.click(screen.getByText('Skills (3)'))
+    fireEvent.click(screen.getByRole('button', { name: '未管理 2' }))
+    fireEvent.click(screen.getByRole('button', { name: '批量管理' }))
+    fireEvent.click(screen.getByRole('button', { name: '选择当前可接管' }))
+    fireEvent.click(screen.getByRole('button', { name: '批量删除 2 个' }))
+
+    fireEvent.click(screen.getByRole('button', { name: '确认删除' }))
+
+    await waitFor(() => expect(screen.queryByText('manual-skill')).not.toBeInTheDocument())
+    expect(screen.getByText('another-skill')).toBeInTheDocument()
+    expect(screen.getByLabelText('选择 another-skill')).toBeChecked()
+    expect(useSkillStoreV2.getState().error).toContain('permission denied')
   })
 
   it('batch deletes shared unmanaged Skills with owner agents', async () => {

--- a/src/test/skillStoreV2.test.ts
+++ b/src/test/skillStoreV2.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { useSkillStoreV2, filteredSkills } from '../stores/skillStoreV2'
-import type { AgentDetail, SkillSummary, SkillManagerOverview, UnmanagedItemDto } from '../services/skillApiV2'
+import type { AgentDetail, SkillSummary, SkillManagerOverview, SkillTargetDetail, UnmanagedItemDto } from '../services/skillApiV2'
 import { skillApiV2 } from '../services/skillApiV2'
 
 function makeSkill(overrides: Partial<SkillSummary> = {}): SkillSummary {
@@ -375,5 +375,105 @@ describe('skillStoreV2 overview shape', () => {
     expect(overview.metrics.centerSkillCount).toBe(3)
     expect(overview.skills[0].id).toBe('test-driven-development')
     expect(overview.settings.defaultDistributeMode).toBe('link')
+  })
+})
+
+describe('skillStoreV2 Agent Skill delete reconciliation', () => {
+  const regularTarget: SkillTargetDetail = {
+    id: 'target-codex',
+    skillId: 'regular',
+    agentId: 'codex',
+    targetPath: '/Users/me/.codex/skills/regular',
+    resolvedTargetPath: null,
+    installMode: 'link',
+    actualMode: 'link',
+    sourceHash: 'hash',
+    currentHash: null,
+    status: 'ok',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    claims: [],
+  }
+  const sharedTarget: SkillTargetDetail = {
+    ...regularTarget,
+    id: 'target-shared',
+    skillId: 'shared',
+    agentId: 'agents',
+    targetPath: '/Users/me/.agents/skills/shared',
+  }
+  const regularUnmanaged: UnmanagedItemDto = {
+    id: 'unmanaged-codex',
+    itemType: 'skill',
+    agentId: 'codex',
+    path: '/Users/me/.codex/skills/unmanaged',
+    inferredSkillId: 'unmanaged',
+    hash: null,
+    reason: 'not_in_center_library',
+  }
+  const sharedUnmanaged: UnmanagedItemDto = {
+    ...regularUnmanaged,
+    id: 'unmanaged-shared',
+    agentId: 'agents',
+    path: '/Users/me/.agents/skills/unmanaged-shared',
+  }
+
+  beforeEach(() => {
+    const detail = makeAgentDetail('codex')
+    detail.skills = [regularTarget]
+    detail.inheritedManagedSkills = [sharedTarget]
+    detail.inheritedUnmanagedSkills = [sharedUnmanaged]
+    const overview = makeOverview({
+      metrics: { centerSkillCount: 2, targetCount: 2, unmanagedCount: 2, issueCount: 0 },
+      agents: [{
+        id: 'codex',
+        displayName: 'Codex',
+        iconKey: 'codex',
+        enabled: true,
+        skillsDir: '/Users/me/.codex/skills',
+        version: null,
+        latestVersion: null,
+        installed: true,
+        managedSkillCount: 1,
+        unmanagedSkillCount: 1,
+      }],
+    })
+    useSkillStoreV2.setState({
+      runtimeEnvironmentId: 'local',
+      selectedAgentId: 'codex',
+      selectedAgentDetail: detail,
+      overview,
+      agents: overview.agents,
+      unmanaged: [regularUnmanaged, sharedUnmanaged],
+    })
+  })
+
+  it('removes successful regular and inherited items atomically', () => {
+    const applied = useSkillStoreV2.getState().removeAgentSkillItems(
+      'local',
+      'codex',
+      ['target-shared'],
+      ['unmanaged-shared'],
+    )
+
+    expect(applied).toBe(true)
+    expect(useSkillStoreV2.getState().selectedAgentDetail?.skills).toEqual([regularTarget])
+    expect(useSkillStoreV2.getState().selectedAgentDetail?.inheritedManagedSkills).toEqual([])
+    expect(useSkillStoreV2.getState().selectedAgentDetail?.inheritedUnmanagedSkills).toEqual([])
+    expect(useSkillStoreV2.getState().unmanaged).toEqual([regularUnmanaged])
+    expect(useSkillStoreV2.getState().overview?.metrics).toMatchObject({ targetCount: 1, unmanagedCount: 1 })
+  })
+
+  it('rejects snapshots from a stale runtime or Agent', () => {
+    const snapshot = {
+      agentDetail: makeAgentDetail('codex'),
+      overview: makeOverview(),
+      unmanaged: [],
+    }
+
+    expect(useSkillStoreV2.getState().applyAgentSkillViewSnapshot('remote', 'codex', snapshot)).toBe(false)
+    expect(useSkillStoreV2.getState().applyAgentSkillViewSnapshot('local', 'claude-code', snapshot)).toBe(false)
+    expect(useSkillStoreV2.getState().selectedAgentDetail?.skills).toEqual([regularTarget])
+    expect(useSkillStoreV2.getState().applyAgentSkillViewSnapshot('local', 'codex', snapshot)).toBe(true)
+    expect(useSkillStoreV2.getState().selectedAgentDetail?.skills).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary

- remove deleted managed and unmanaged Skills from the local store immediately while keeping failed items visible
- replace post-delete scan chains with one guarded composite Agent Skill refresh and a single retry
- avoid local rescans and remote per-item inventory rebuilds during batch deletion
- cover local, remote, store, and interaction behavior with regression tests

## Validation

- `pnpm lint`
- `pnpm test:run` (53 files, 649 tests)
- `pnpm build`
- `cargo check --manifest-path src-tauri/Cargo.toml`
- `cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings`

Supplemental full Rust testing passed 546 tests with 5 ignored; the unchanged environment-dependent `kimi_does_not_claim_agentbro_center_skills` assertion fails locally because Kimi is installed on this machine.

Closes #94