### PR TITLE
feat: unify Codex AgentRunState observability

### DIFF
--- a/docs/architecture/baseline.md
+++ b/docs/architecture/baseline.md
@@ -1,0 +1,109 @@
+# Control Tower Phase 0 Windows Baseline
+
+## Scope
+
+This baseline records the current AgentBro architecture before Control Tower
+product work begins. Phase 0 intentionally makes no runtime or product changes.
+
+- Upstream: <https://github.com/shirenchuang/agentbro>
+- Baseline commit: `d03145cd2876c64841a202b0291faeb51d760474`
+- Target: Windows x64
+- Toolchain: Node.js 22.23.2, pnpm 11.19.0, Rust 1.98.0 (MSVC)
+
+## Validation
+
+| Check | Result | Notes |
+| --- | --- | --- |
+| `pnpm install --frozen-lockfile` | Pass | Existing lockfile used |
+| `pnpm lint` | Pass | No lint errors |
+| `pnpm test:run` | Pass | 53 files, 649 tests |
+| `pnpm build` | Pass | Vite production build |
+| `cargo check --manifest-path src-tauri/Cargo.toml` | Pass | 21 existing dead-code warnings |
+| `pnpm build:bridge` | Pass | Windows bridge executable built |
+| Native startup | Pass | Hook server listened on `127.0.0.1:17894`; the Tauri process and 420×52 island window stayed responsive |
+| Codex Hook → visible Island | Partial | The empty island was transparent as designed, but an injected test event did not become a visible session |
+
+The last visual check should not be repeated against a normal Windows profile
+until startup can suppress automatic hook installation. Overriding
+`USERPROFILE`, `APPDATA`, and `LOCALAPPDATA` isolated WebView/app data but did
+not isolate the Windows home directory used for agent hook discovery. Native
+startup therefore installed Claude hooks in the real profile. Those test
+changes and all temporary runtime data were removed after validation.
+
+## Current event flow
+
+```mermaid
+flowchart LR
+    Codex[Codex CLI hooks.json] --> Bridge[agentbro-bridge]
+    Bridge -->|TCP 127.0.0.1:17894| HookServer
+    HookServer --> Adapter[CodexAdapter.parse_event]
+    Adapter --> Event[AgentEvent]
+    Event --> Store[SessionStore]
+    Store -->|session-update| Tauri[useTauri]
+    Tauri --> Zustand[sessionStore]
+    Zustand --> Island[NotchPanel]
+    Zustand --> Monitor[Agent Monitor]
+    HookServer -->|blocking reply| Bridge
+
+    AppServer[Codex app-server WebSocket] --> Store
+    AppServer --> Usage[Rate-limit snapshots]
+```
+
+There are two Codex ingestion paths:
+
+1. Hooks are the primary real-time path. The compiled bridge normalizes hook
+   payloads, forwards one JSON line to the local hook server, and keeps the
+   connection open for approvals or questions.
+2. Codex app-server synchronization supplements hooks with thread state,
+   approvals, questions, steering, and account rate limits.
+
+Both paths converge on the backend `SessionStore`. The frontend Zustand store
+is a UI projection, not the system of record.
+
+## Existing boundaries
+
+| Boundary | Current responsibility | Control Tower rule |
+| --- | --- | --- |
+| Agent adapters | Install/remove hooks and normalize provider payloads into `AgentEvent` | Keep provider-specific parsing here |
+| Bridge and hook server | Local transport, blocking replies, raw-event ring buffer | Keep transport separate from product models |
+| `SessionStore` | Live session state and `session-update` broadcasts | Reuse for live state; do not turn it into durable history |
+| Island | Compact active-session state, approvals, questions, and completion overlays | Keep it a projection of task state |
+| Agent Monitor | Session summaries, detail, timeline, and transcript views | Rebuild its timeline from durable trace data when available |
+| Notifications | Native completion/error/attention delivery | Trigger from normalized state transitions |
+| Usage readers | Codex rate-limit snapshots with JSONL fallback and source metadata | Preserve source and freshness; never invent cost |
+
+## Minimal extension points
+
+No new abstraction is required in Phase 0. The next implementation should add
+durable product data behind the existing event pipeline:
+
+- **Task:** derive a stable task ID, parent/child relationship, agent, run, and
+  status from normalized events and sessions; persist it in SQLite.
+- **Trace:** append normalized events with timestamp, source, session/task IDs,
+  and an optional raw-event reference; make Monitor a projection of this log.
+- **Usage:** persist provider snapshots with `source`, `updated_at`, and
+  freshness/estimate flags. Only calculate currency cost when both model usage
+  and pricing are trustworthy.
+
+Adapters should remain inputs. `SessionStore` should remain the live cache.
+Task, Trace, and Usage should be backend domain records exposed through Tauri
+commands/events; the frontend should not duplicate their business logic.
+
+## Known gaps and risks
+
+1. The current startup path may automatically modify agent hook files. A safe
+   development/test mode is needed before repeatable native E2E testing.
+2. `SessionStore`, raw-event history, and derived task/tool state are in memory;
+   there is no durable Task/Trace model.
+3. Current usage data describes quota windows, not trustworthy per-task cost;
+   several provider readers are declared but not wired.
+4. Windows Hook → visible Island remains an open E2E check.
+5. Redistribution requires replacing the AgentBro product name and identity;
+   branding work is outside this baseline.
+
+## Phase 1 entry
+
+The smallest safe first change is an explicit development/test startup mode
+that skips automatic hook installation and accepts isolated agent/app data
+paths. After that check is repeatable, implement the minimal SQLite Task and
+Trace records on the existing `AgentEvent` → `SessionStore` path.

--- a/src-tauri/src/hooks/server.rs
+++ b/src-tauri/src/hooks/server.rs
@@ -15,7 +15,7 @@ use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::{oneshot, Mutex};
 
 use super::session_store::{
-    ContextWindowInfo, PendingPermission, PendingPlan, PendingQuestion,
+    AgentRunStatus, ContextWindowInfo, PendingPermission, PendingPlan, PendingQuestion,
     QuestionItem as PendingQuestionItem, QuestionOption as PendingQuestionOption, RateLimitInfo,
     SessionPhase, SessionStore, SubagentInfo, SubagentStopUpdate,
 };
@@ -1962,6 +1962,12 @@ impl HookServer {
                         if subagent.status == "running" {
                             subagent.status = "completed".to_string();
                         }
+                    }
+                    if s.phase == SessionPhase::Ready {
+                        s.run_state.status = AgentRunStatus::Completed;
+                        s.run_state.phase = Some("done".to_string());
+                        s.run_state.current_action = Some(truncated.clone());
+                        s.run_state.updated_at = chrono::Utc::now().to_rfc3339();
                     }
                 });
                 Self::refresh_cache_ttl_from_transcript(store, session_id, _raw);

--- a/src-tauri/src/hooks/session_store.rs
+++ b/src-tauri/src/hooks/session_store.rs
@@ -23,6 +23,50 @@ pub enum SessionPhase {
     Interrupted,
 }
 
+/// Provider-neutral lifecycle status exposed with every session snapshot.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentRunStatus {
+    Idle,
+    Starting,
+    Running,
+    WaitingInput,
+    WaitingPermission,
+    Blocked,
+    RateLimited,
+    Error,
+    Completed,
+    Cancelled,
+    #[default]
+    Unknown,
+}
+
+fn session_phase_name(phase: &SessionPhase) -> &'static str {
+    match phase {
+        SessionPhase::Ready => "ready",
+        SessionPhase::Idle => "idle",
+        SessionPhase::Processing => "processing",
+        SessionPhase::WaitingApproval => "waiting_approval",
+        SessionPhase::WaitingInput => "waiting_input",
+        SessionPhase::Compacting => "compacting",
+        SessionPhase::Done => "done",
+        SessionPhase::Error => "error",
+        SessionPhase::Interrupted => "interrupted",
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentRunState {
+    pub agent: String,
+    pub session_id: Option<String>,
+    pub status: AgentRunStatus,
+    pub phase: Option<String>,
+    pub current_action: Option<String>,
+    pub started_at: Option<String>,
+    pub updated_at: String,
+}
+
 impl SessionPhase {
     /// Check whether transitioning from `self` to `next` is valid.
     pub fn can_transition_to(&self, next: &SessionPhase) -> bool {
@@ -291,6 +335,8 @@ pub struct SessionState {
     pub cwd: String,
     pub terminal: String,
     pub phase: SessionPhase,
+    #[serde(default)]
+    pub run_state: AgentRunState,
     pub started_at: i64,
     pub duration: i64,
     pub tokens: TokenUsage,
@@ -337,7 +383,7 @@ impl SessionState {
         cwd: String,
         terminal: String,
     ) -> Self {
-        Self {
+        let mut session = Self {
             id,
             agent_type,
             engine_label: None,
@@ -347,6 +393,7 @@ impl SessionState {
             cwd,
             terminal,
             phase: SessionPhase::Ready,
+            run_state: AgentRunState::default(),
             started_at: Utc::now().timestamp(),
             duration: 0,
             tokens: TokenUsage::default(),
@@ -382,6 +429,68 @@ impl SessionState {
             last_thought: None,
             is_yolo_mode: false,
             model: None,
+        };
+        session.refresh_run_state();
+        session.run_state.status = AgentRunStatus::Starting;
+        session
+    }
+
+    pub fn refresh_run_state(&mut self) {
+        let response_completed = self.phase == SessionPhase::Ready
+            && self.run_state.status == AgentRunStatus::Completed
+            && self.last_response.is_some();
+        let status = if response_completed {
+            AgentRunStatus::Completed
+        } else if self.pending_permission.is_some()
+            || self.pending_plan.is_some()
+            || self.phase == SessionPhase::WaitingApproval
+        {
+            AgentRunStatus::WaitingPermission
+        } else if self.pending_question.is_some() || self.phase == SessionPhase::WaitingInput {
+            AgentRunStatus::WaitingInput
+        } else {
+            match self.phase {
+                SessionPhase::Processing | SessionPhase::Compacting => AgentRunStatus::Running,
+                SessionPhase::Error => AgentRunStatus::Error,
+                SessionPhase::Done => AgentRunStatus::Completed,
+                SessionPhase::Interrupted => AgentRunStatus::Cancelled,
+                SessionPhase::Ready | SessionPhase::Idle => AgentRunStatus::Idle,
+                SessionPhase::WaitingApproval | SessionPhase::WaitingInput => {
+                    AgentRunStatus::Unknown
+                }
+            }
+        };
+        let phase = Some(if response_completed {
+            "done".to_string()
+        } else {
+            session_phase_name(&self.phase).to_string()
+        });
+        let current_action = self
+            .last_tool_name
+            .as_ref()
+            .map(|tool| match self.last_tool_target.as_deref() {
+                Some(target) if !target.is_empty() => format!("{tool}: {target}"),
+                _ => tool.clone(),
+            })
+            .or_else(|| self.description.clone());
+        let started_at = chrono::DateTime::<Utc>::from_timestamp(self.started_at, 0)
+            .map(|value| value.to_rfc3339());
+        let changed = self.run_state.agent != self.agent_type
+            || self.run_state.session_id.as_deref() != Some(self.id.as_str())
+            || self.run_state.status != status
+            || self.run_state.phase != phase
+            || self.run_state.current_action != current_action
+            || self.run_state.started_at != started_at;
+        if changed || self.run_state.updated_at.is_empty() {
+            self.run_state = AgentRunState {
+                agent: self.agent_type.clone(),
+                session_id: Some(self.id.clone()),
+                status,
+                phase,
+                current_action,
+                started_at,
+                updated_at: Utc::now().to_rfc3339(),
+            };
         }
     }
 
@@ -807,6 +916,7 @@ impl SessionStore {
             .map(|entry| {
                 let mut s = entry.value().clone();
                 s.update_duration();
+                s.refresh_run_state();
                 s
             })
             .collect()
@@ -866,6 +976,7 @@ impl SessionStore {
         self.sessions.get(session_id).map(|s| {
             let mut session = s.value().clone();
             session.update_duration();
+            session.refresh_run_state();
             session
         })
     }
@@ -1119,5 +1230,29 @@ mod tests {
 
         assert_eq!(store.get_all_sessions().len(), 1);
         assert!(store.get_session("s1").is_some());
+    }
+
+    #[test]
+    fn session_snapshot_exposes_provider_neutral_run_state() {
+        let store = seeded_store();
+        store.update_session("s1", |session| {
+            session.phase = SessionPhase::Processing;
+            session.last_tool_name = Some("Bash".to_string());
+            session.last_tool_target = Some("pnpm test".to_string());
+        });
+
+        let session = store.get_session("s1").expect("session should exist");
+        assert_eq!(session.run_state.agent, "claude-code");
+        assert_eq!(session.run_state.status, AgentRunStatus::Running);
+        assert_eq!(session.run_state.phase.as_deref(), Some("processing"));
+        assert_eq!(
+            session.run_state.current_action.as_deref(),
+            Some("Bash: pnpm test")
+        );
+        assert!(!session.run_state.updated_at.is_empty());
+
+        let json = serde_json::to_value(session).expect("session should serialize");
+        assert_eq!(json["runState"]["status"], "running");
+        assert_eq!(json["runState"]["sessionId"], "s1");
     }
 }

--- a/src-tauri/src/menu_bar.rs
+++ b/src-tauri/src/menu_bar.rs
@@ -49,14 +49,11 @@ pub fn labels(language: &str) -> MenuBarLabels {
 pub fn build_tray_menu<M: Manager<Wry>>(manager: &M, language: &str) -> tauri::Result<Menu<Wry>> {
     let labels = labels(language);
     let show_item = MenuItemBuilder::with_id("show", labels.open).build(manager)?;
-    let skill_packs =
-        MenuItemBuilder::with_id(SKILL_PACK_PICKER_ID, labels.skill_packs).build(manager)?;
     let settings_item = MenuItemBuilder::with_id("settings", labels.settings).build(manager)?;
     let quit_item = MenuItemBuilder::with_id("quit", labels.quit).build(manager)?;
 
     MenuBuilder::new(manager)
         .item(&show_item)
-        .item(&skill_packs)
         .item(&settings_item)
         .separator()
         .item(&quit_item)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,9 +12,7 @@ import './styles/globals.css'
 
 const ClaudeHookUiLab = lazy(() => import('./components/dev/ClaudeHookUiLab').then((module) => ({ default: module.ClaudeHookUiLab })))
 const NotchPanel = lazy(() => import('./components/notch/NotchPanel').then((module) => ({ default: module.NotchPanel })))
-const PetApp = lazy(() => import('./PetApp').then((module) => ({ default: module.PetApp })))
 const SettingsApp = lazy(() => import('./components/settings/SettingsApp').then((module) => ({ default: module.SettingsApp })))
-const SkillPackPicker = lazy(() => import('./components/tray/SkillPackPicker').then((module) => ({ default: module.SkillPackPicker })))
 
 // Fields whose source of truth lives in the Rust backend and is broadcast via
 // the `config-changed` event. We must NOT replay stale values from another
@@ -217,14 +215,9 @@ function App() {
   // Wait for detection
   if (windowLabel === null) return null
 
-  // Pet companion window — independent, only renders the pet sprite layer.
-  if (windowLabel === 'pet') {
-    return <Suspense fallback={null}><PetApp /></Suspense>
-  }
-
-  if (windowLabel === 'skill-pack-picker') {
-    return <Suspense fallback={null}><SkillPackPicker /></Suspense>
-  }
+  // Product Slimming keeps the underlying windows available for later cleanup
+  // but exposes no Pet or Skill Pack UI in the Control Tower shell.
+  if (windowLabel === 'pet' || windowLabel === 'skill-pack-picker') return null
 
   // Settings window
   if (windowLabel === 'settings') {

--- a/src/components/notch/CollapsedBar.tsx
+++ b/src/components/notch/CollapsedBar.tsx
@@ -14,6 +14,7 @@ import { isDarkColorTheme, useThemeStore } from '../../stores/themeStore'
 import { sessionNeedsAttention } from '../../utils/islandInteraction'
 import { getStringField, parseToolInput } from '../../utils/permissionPreview'
 import { getToolActivityLabel } from '../../utils/toolLabels'
+import { statusFromSession } from '../../utils/agentRunState'
 import { RateLimitBar } from './RateLimitBar'
 import { SpriteCanvas } from './SpriteCanvas'
 import './CollapsedBar.css'
@@ -79,6 +80,20 @@ const PHASE_LABELS: Record<SessionPhase, string> = {
   done: 'notch.taskComplete',
   error: 'notch.error',
   interrupted: 'notch.interrupted',
+}
+
+const RUN_STATUS_LABELS: Partial<Record<NonNullable<SessionState['runState']>['status'], string>> = {
+  starting: 'notch.working',
+  running: 'notch.working',
+  waiting_permission: 'notch.needsApproval',
+  waiting_input: 'notch.waitingInput',
+  error: 'notch.error',
+  completed: 'notch.taskComplete',
+  cancelled: 'notch.interrupted',
+}
+
+function runStatus(session: SessionState): NonNullable<SessionState['runState']>['status'] {
+  return session.runState?.status ?? statusFromSession(session)
 }
 
 function isGenericProcessingDescription(text: string | undefined): boolean {
@@ -167,9 +182,10 @@ type WaitingSummary = {
 
 function getWaitingSummary(session: SessionState, t: (key: string, options?: Record<string, unknown>) => string): WaitingSummary | null {
   const project = session.project || 'Session'
+  const status = runStatus(session)
 
-  if (session.pendingPermission || session.phase === 'waiting_approval') {
-    const toolName = session.pendingPermission?.toolName
+  if (session.pendingPermission || status === 'waiting_permission' || session.phase === 'waiting_approval') {
+    const toolName = session.pendingPermission?.toolName || session.runState?.currentAction
     const parsedInput = parseToolInput(session.pendingPermission?.toolInput)
     const target = session.pendingPermission?.diff?.filePath
       || getStringField(parsedInput, ['file_path', 'filePath', 'path', 'url', 'command', 'query', 'pattern', 'raw'])
@@ -182,7 +198,7 @@ function getWaitingSummary(session: SessionState, t: (key: string, options?: Rec
     }
   }
 
-  if (session.pendingQuestion || session.phase === 'waiting_input') {
+  if (session.pendingQuestion || status === 'waiting_input' || session.phase === 'waiting_input') {
     return {
       project,
       label: t('notch.waitingInput', { defaultValue: 'Waiting for input' }),
@@ -213,14 +229,16 @@ function CollapsedWaitingStatus({ summary }: { summary: WaitingSummary }) {
 function getCarouselSlides(session: SessionState, t: (key: string) => string): string[] {
   const slides: string[] = [session.project]
 
-  if (session.lastToolName) {
+  if (session.runState?.currentAction && !isGenericProcessingDescription(session.runState.currentAction)) {
+    slides.push(session.runState.currentAction.split('\n')[0])
+  } else if (session.lastToolName) {
     const target = session.lastToolTarget ? `: ${session.lastToolTarget}` : ''
     slides.push(`${getToolActivityLabel(t, session.lastToolName)}${target}`)
   } else if (session.description && !isGenericProcessingDescription(session.description)) {
     slides.push(session.description.split('\n')[0])
   }
 
-  const statusKey = PHASE_LABELS[session.phase]
+  const statusKey = RUN_STATUS_LABELS[runStatus(session)] || PHASE_LABELS[session.phase]
   const status = statusKey ? t(statusKey) : session.phase
   if (status && status !== slides[0]) slides.push(status)
 
@@ -320,16 +338,16 @@ export function CollapsedBar({ sessions, panelState, rateLimits, usageSnapshots,
   const isExpanded = panelState !== 'collapsed'
   const updateAvailable = useUpdateStore((s) => s.availableVersion)
   const alertCount = sessions.filter(s => computePriority(s) >= PRIORITY.attention).length
-  const workingCount = sessions.filter(s => s.phase === 'processing' || s.phase === 'compacting').length
+  const workingCount = sessions.filter(s => runStatus(s) === 'running').length
   const waitingCount = sessions.filter(sessionNeedsAttention).length
   const allIdle = sessions.length > 0 && sessions.every(s => computePriority(s) <= PRIORITY.idle)
   const showTips = tipsEnabled && (sessions.length === 0 || allIdle)
   const emptyText = focusFilteredEmpty ? t('notch.noSessionInFocus') : t('notch.waitingForSessions')
   const showBrandEmpty = sessions.length === 0 && !focusFilteredEmpty && !showTips
-  const isCompacting = lead?.phase === 'compacting'
-  const isThinking = lead?.phase === 'processing' && !lead?.lastToolName
+  const isCompacting = lead?.runState?.phase === 'compacting' || lead?.phase === 'compacting'
+  const isThinking = lead ? runStatus(lead) === 'running' && !lead.runState?.currentAction && !lead.lastToolName : false
   const isYolo = lead?.isYoloMode
-  const hasError = lead?.phase === 'error'
+  const hasError = lead ? runStatus(lead) === 'error' : false
   const effectiveRateLimits = selectEffectiveRateLimits(sessions, lead, rateLimits, usageSnapshots)
   const shouldShowUsageQuota = usageQueryEnabled && showUsageQuota && Boolean(effectiveRateLimits)
   const ratePct = shouldShowUsageQuota ? effectiveRateLimits?.fiveHourUsage : undefined

--- a/src/components/notch/NotchPanel.tsx
+++ b/src/components/notch/NotchPanel.tsx
@@ -15,6 +15,7 @@ import { getSessionListSubagents } from '../../utils/subagents'
 import { shortcutMatchesEvent } from '../../utils/keyboardShortcuts'
 import { primaryModifierPressed } from '../../utils/platform'
 import { energyIntervalMs, getAppEnergyMode, shouldSilenceAfterWake } from '../../utils/energyPolicy'
+import { filterCodexSessions } from '../../utils/agentRunState'
 import { CollapsedBar } from './CollapsedBar'
 import { UpdateBanner } from './UpdateBanner'
 import { HoverList } from './HoverList'
@@ -414,16 +415,22 @@ export function NotchPanel() {
     }
   }, [followFocus, sessions])
 
+  const codexSessions = useMemo(() => {
+    const filtered = filterCodexSessions(sessions)
+    // Keep manually supplied legacy snapshots usable while the backend rolls
+    // out the normalized runState field. Live snapshots are always filtered.
+    return sessions.some((session) => session.runState) ? filtered : sessions
+  }, [sessions])
   const visibleSessions = useMemo(
-    () => getFollowFocusVisibleSessions(sessions, followFocus, focusedSessionIds),
-    [focusedSessionIds, followFocus, sessions],
+    () => getFollowFocusVisibleSessions(codexSessions, followFocus, focusedSessionIds),
+    [codexSessions, focusedSessionIds, followFocus],
   )
   const displayedSessions = useMemo(() => (
     islandMonitorSubagents
       ? visibleSessions
       : visibleSessions.map((session) => ({ ...session, subagents: [] }))
   ), [islandMonitorSubagents, visibleSessions])
-  const focusFilteredEmpty = followFocus && focusedSessionIds !== null && sessions.length > 0 && visibleSessions.length === 0
+  const focusFilteredEmpty = followFocus && focusedSessionIds !== null && codexSessions.length > 0 && visibleSessions.length === 0
 
   const markActiveBlockingOverlayInline = useCallback(() => {
     const overlay = useSessionStore.getState().activeOverlay
@@ -554,8 +561,8 @@ export function NotchPanel() {
 
   // Track sessions needing blocking attention.
   const blockingAttentionCount = useMemo(
-    () => sessions.filter(sessionNeedsAttention).length,
-    [sessions],
+    () => visibleSessions.filter(sessionNeedsAttention).length,
+    [visibleSessions],
   )
 
   const activePriority = useMemo(
@@ -564,14 +571,14 @@ export function NotchPanel() {
   )
 
   const interaction = useMemo(() => deriveIslandInteraction({
-    sessions,
+    sessions: visibleSessions,
     panelState,
     activeOverlay,
     interactionMode,
     persistentIdleHidden,
     keepCompactAfterActive,
     wakeSilenced: Date.now() < wakeSilencedUntil,
-  }), [sessions, panelState, activeOverlay, interactionMode, persistentIdleHidden, keepCompactAfterActive, wakeSilencedUntil])
+  }), [visibleSessions, panelState, activeOverlay, interactionMode, persistentIdleHidden, keepCompactAfterActive, wakeSilencedUntil])
 
   // Auto-expand on new blocking attention, and collapse shortly after it resolves.
   const prevAttentionRef = useRef(0)

--- a/src/components/settings/FirstRunWelcome.tsx
+++ b/src/components/settings/FirstRunWelcome.tsx
@@ -1,21 +1,11 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useConfigStore } from '../../stores/configStore'
-import { setAnalyticsEnabled as setAnalyticsEnabledBackend, setIslandSurfaceOptions } from '../../services/tauriApi'
-
-type SurfaceMode = 'island' | 'pet'
-
-const surfaceOptions: Array<{ value: SurfaceMode; labelKey: string; mark: string }> = [
-  { value: 'island', labelKey: 'settings.surfaceIsland', mark: 'I' },
-  { value: 'pet', labelKey: 'settings.surfacePet', mark: 'P' },
-]
+import { setAnalyticsEnabled as setAnalyticsEnabledBackend } from '../../services/tauriApi'
 
 export function FirstRunWelcome() {
   const { t } = useTranslation()
-  const initialSurfaceMode = useConfigStore((s) => s.islandSurfaceMode)
-  const initialPetScale = useConfigStore((s) => s.islandPetScale)
   const updateConfig = useConfigStore((s) => s.updateConfig)
-  const [surfaceMode, setSurfaceMode] = useState<SurfaceMode>(initialSurfaceMode)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -24,22 +14,12 @@ export function FirstRunWelcome() {
     const previous = useConfigStore.getState()
     setSaving(true)
     setError(null)
-    updateConfig('islandSurfaceMode', surfaceMode)
-    updateConfig('islandPetWindowOrigin', null)
-    updateConfig('islandPetWindowAnchor', null)
     updateConfig('analyticsEnabled', true)
     updateConfig('analyticsConsentPromptCompleted', true)
 
     try {
-      await setIslandSurfaceOptions({
-        islandSurfaceMode: surfaceMode,
-        islandPetScale: initialPetScale,
-      })
       await setAnalyticsEnabledBackend(true)
     } catch (err) {
-      updateConfig('islandSurfaceMode', previous.islandSurfaceMode)
-      updateConfig('islandPetWindowOrigin', previous.islandPetWindowOrigin)
-      updateConfig('islandPetWindowAnchor', previous.islandPetWindowAnchor)
       updateConfig('analyticsEnabled', previous.analyticsEnabled)
       updateConfig('analyticsConsentPromptCompleted', previous.analyticsConsentPromptCompleted)
       setError(err instanceof Error ? err.message : String(err))
@@ -62,30 +42,8 @@ export function FirstRunWelcome() {
         </div>
         <div className="first-run-dialog__header">
           <div className="first-run-dialog__eyebrow">{t('settings.welcomeEyebrow')}</div>
-          <h1 id="first-run-title">{t('settings.welcomeTitle')}</h1>
-          <p>{t('settings.welcomeSubtitle')}</p>
-        </div>
-
-        <div className="first-run-dialog__section">
-          <div>
-            <h2>{t('settings.welcomeSurface')}</h2>
-            <p>{t('settings.welcomeSurfaceDesc')}</p>
-          </div>
-          <div className="first-run-surface" role="radiogroup" aria-label={t('settings.welcomeSurface')}>
-            {surfaceOptions.map((option) => (
-              <button
-                key={option.value}
-                className={`first-run-surface__option${surfaceMode === option.value ? ' first-run-surface__option--active' : ''}`}
-                type="button"
-                role="radio"
-                aria-checked={surfaceMode === option.value}
-                onClick={() => setSurfaceMode(option.value)}
-              >
-                <span className="first-run-surface__mark" aria-hidden="true">{option.mark}</span>
-                <span>{t(option.labelKey)}</span>
-              </button>
-            ))}
-          </div>
+          <h1 id="first-run-title">{t('settings.title')}</h1>
+          <p>{t('notch.slogan')}</p>
         </div>
 
         {error && (

--- a/src/components/settings/SettingsApp.tsx
+++ b/src/components/settings/SettingsApp.tsx
@@ -13,12 +13,10 @@ import { AboutSection } from './sections/AboutSection'
 import { SwitchSection } from './sections/SwitchSection'
 import { RemoteServersSection } from './sections/RemoteServersSection'
 import { SkillManagerSection } from '../skills-v2/SkillManagerSection'
-import { MarketplaceInstallTaskDock } from '../skills-v2/MarketplaceInstallTaskDock'
 import { useUpdater } from '../../hooks/useUpdater'
 import { useConfigStore } from '../../stores/configStore'
 import { isTauri } from '../../services/tauriApi'
 import type { IslandSettingsView, MonitorSettingsView } from '../../types/capability'
-import { useSkillStoreV2 } from '../../stores/skillStoreV2'
 import '../../styles/settings.css'
 
 const sections: Record<string, () => ReactNode> = {
@@ -36,13 +34,11 @@ export function SettingsApp({ onClose }: SettingsAppProps) {
   const updater = useUpdater()
   const autoInstallUpdate = useConfigStore((s) => s.autoInstallUpdate)
   const analyticsConsentPromptCompleted = useConfigStore((s) => s.analyticsConsentPromptCompleted)
-  const [activeSection, setActiveSection] = useState('general')
+  const [activeSection, setActiveSection] = useState('tasks')
   const [activeIslandView, setActiveIslandView] = useState<IslandSettingsView>('overview')
   const [activeMonitorView, setActiveMonitorView] = useState<MonitorSettingsView>('overview')
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
   const [updateMinimized, setUpdateMinimized] = useState(false)
-  const skillActiveTab = useSkillStoreV2((state) => state.activeTab)
-  const skillInstallTab = useSkillStoreV2((state) => state.activeInstallTab)
   const SectionComponent = sections[activeSection] ?? GeneralSection
   const isMarketSection = activeSection === 'island' && activeIslandView === 'market'
   const isSkillManager = activeSection === 'skill-manager-v2'
@@ -66,13 +62,6 @@ export function SettingsApp({ onClose }: SettingsAppProps) {
 
   const handleCloseRequest = async () => {
     if (await confirmCloseWhileDownloading()) onClose()
-  }
-
-  const openMarketplaceInstallTask = () => {
-    const skillStore = useSkillStoreV2.getState()
-    skillStore.setTab('install')
-    skillStore.setInstallTab('official')
-    setActiveSection('skill-manager-v2')
   }
 
   useEffect(() => {
@@ -142,7 +131,13 @@ export function SettingsApp({ onClose }: SettingsAppProps) {
             exit={{ opacity: 0, y: -8 }}
             transition={{ duration: 0.15 }}
           >
-            {activeSection === 'island' ? (
+            {activeSection === 'tasks' ? (
+              <AgentMonitorSection activeView="sessions" />
+            ) : activeSection === 'usage' ? (
+              <section className="setting-section">
+                <h2>{t('settings.usage', { defaultValue: 'Usage' })}</h2>
+              </section>
+            ) : activeSection === 'island' ? (
               <IslandSection activeView={activeIslandView} />
             ) : activeSection === 'monitor' ? (
               <AgentMonitorSection activeView={activeMonitorView} />
@@ -189,10 +184,6 @@ export function SettingsApp({ onClose }: SettingsAppProps) {
         />
       )}
       {!analyticsConsentPromptCompleted && <FirstRunWelcome />}
-      <MarketplaceInstallTaskDock
-        hidden={activeSection === 'skill-manager-v2' && skillActiveTab === 'install' && skillInstallTab === 'official'}
-        onOpen={openMarketplaceInstallTask}
-      />
     </div>
   )
 }

--- a/src/components/settings/SettingsSidebar.tsx
+++ b/src/components/settings/SettingsSidebar.tsx
@@ -12,8 +12,10 @@ import { RuntimeEnvironmentSwitcher } from './RuntimeEnvironmentSwitcher'
 interface SidebarItem {
   id: string
   labelKey: string
+  defaultLabel?: string
   icon: string
   iconBg: string
+  hidden?: boolean
 }
 
 interface SidebarGroup {
@@ -31,16 +33,18 @@ interface AgentDropTarget {
 const sidebarGroups: SidebarGroup[] = [
   {
     items: [
-      { id: 'general', labelKey: 'settings.general', icon: '⚙', iconBg: '#8E8E93' },
-      { id: 'island', labelKey: 'settings.island.title', icon: '🏝', iconBg: '#5856D6' },
-      { id: 'skill-manager-v2', labelKey: 'settings.skillManager', icon: '🧩', iconBg: '#34C759' },
-      { id: 'remote-servers', labelKey: 'settings.remoteServers.title', icon: '>_', iconBg: '#009C95' },
+      { id: 'tasks', labelKey: 'settings.tasks', defaultLabel: 'Tasks', icon: '✓', iconBg: '#34C759' },
+      { id: 'usage', labelKey: 'settings.usage', defaultLabel: 'Usage', icon: '▥', iconBg: '#007AFF' },
+      { id: 'general', labelKey: 'settings.controlTowerSettings', defaultLabel: 'Settings', icon: '⚙', iconBg: '#8E8E93' },
+      { id: 'island', labelKey: 'settings.island.title', icon: '🏝', iconBg: '#5856D6', hidden: true },
+      { id: 'skill-manager-v2', labelKey: 'settings.skillManager', icon: '🧩', iconBg: '#34C759', hidden: true },
+      { id: 'remote-servers', labelKey: 'settings.remoteServers.title', icon: '>_', iconBg: '#009C95', hidden: true },
     ],
   },
   {
     labelKey: 'settings.agentBro',
     items: [
-      { id: 'about', labelKey: 'settings.about', icon: 'ℹ', iconBg: '#007AFF' },
+      { id: 'about', labelKey: 'settings.about', icon: 'ℹ', iconBg: '#007AFF', hidden: true },
     ],
   },
 ]
@@ -434,20 +438,22 @@ export function SettingsSidebar({
     <nav className={sidebarClassName}>
       {toggleSidebar}
       {sidebarGroups.map((group, gi) => (
-        <div key={gi}>
+        <div key={gi} hidden={group.items.every((item) => item.hidden)}>
           {gi > 0 && <div className="settings-sidebar__separator" />}
           {group.labelKey && <div className="settings-sidebar__group-label">{t(group.labelKey)}</div>}
           <div className="settings-sidebar__group">
             {group.items.map((item) => {
               const isActive = activeSection === item.id
+              const label = t(item.labelKey, { defaultValue: item.defaultLabel ?? item.labelKey })
               return (
                 <div
                   key={item.id}
                   role="button"
                   tabIndex={0}
+                  hidden={item.hidden}
                   className={`settings-sidebar__item ${isActive ? 'settings-sidebar__item--active' : ''}`}
-                  aria-label={t(item.labelKey)}
-                  title={t(item.labelKey)}
+                  aria-label={label}
+                  title={label}
                   onClick={() => {
                     if (item.id === 'skill-manager-v2' && marketplaceInstallTask) openSkillTab('install')
                     onSelect(item.id)
@@ -465,7 +471,7 @@ export function SettingsSidebar({
                   >
                     {item.icon}
                   </span>
-                  <span className="settings-sidebar__label-text">{t(item.labelKey)}</span>
+                  <span className="settings-sidebar__label-text">{label}</span>
                   {item.id === 'skill-manager-v2' && marketplaceTaskBadge && (
                     <span
                       className={`settings-sidebar__task-badge${marketplaceInstallTask?.busy ? ' settings-sidebar__task-badge--busy' : ''}`}

--- a/src/hooks/useTauri.ts
+++ b/src/hooks/useTauri.ts
@@ -13,6 +13,7 @@ import { useThemeStore } from '../stores/themeStore'
 import type { SoundChoice } from '../stores/configStore'
 import type { SessionState, DiffContent, AgentType, ToolStatus, ChatMessage, RateLimitInfo } from '../types/agent'
 import { energyIntervalMs, getAppEnergyMode } from '../utils/energyPolicy'
+import { agentRunStateFromSession } from '../utils/agentRunState'
 
 type Unlisten = () => void
 type TauriInitScope = string | null
@@ -174,7 +175,7 @@ function buildDiffFromToolInput(name: string, input: Record<string, unknown>): D
   return undefined
 }
 
-function transformSession(bs: BackendSession): SessionState {
+export function transformSession(bs: BackendSession): SessionState {
   // Preserve existing chatHistory/subagents/activeTools from the store
   // so that replaceAllSessions doesn't wipe them on each backend update
   const existing = useSessionStore.getState().sessions[bs.id]
@@ -184,7 +185,7 @@ function transformSession(bs: BackendSession): SessionState {
     : (existing?.subagents ?? [])
   const lastUserMessage = bs.lastUserMessage ?? existing?.lastUserMessage
 
-  return {
+  const session: SessionState = {
     id: bs.id,
     agentType: bs.agentType as AgentType,
     engineLabel: bs.engineLabel ?? undefined,
@@ -284,6 +285,11 @@ function transformSession(bs: BackendSession): SessionState {
     lastUserMessageAt: lastUserMessage === existing?.lastUserMessage ? existing?.lastUserMessageAt : undefined,
     responseText: bs.lastResponse ?? undefined,
     description: bs.lastThought ?? bs.description ?? undefined,
+  }
+
+  return {
+    ...session,
+    runState: bs.runState ?? agentRunStateFromSession(session),
   }
 }
 

--- a/src/services/tauriApi.ts
+++ b/src/services/tauriApi.ts
@@ -2,7 +2,7 @@
  * Typed wrappers for Tauri commands with graceful browser-dev-mode fallbacks.
  */
 
-import type { RateLimitInfo, SessionNotice, SessionState } from '../types/agent'
+import type { AgentRunState, RateLimitInfo, SessionNotice, SessionState } from '../types/agent'
 import type { ThemeConfig } from '../types/theme'
 import type { PetMetadata } from '../types/pet'
 import { useConfigStore } from '../stores/configStore'
@@ -77,6 +77,7 @@ export interface BackendSession {
   cwd: string
   terminal: string
   phase: string
+  runState?: AgentRunState | null
   startedAt: number
   duration: number
   tokens: { input: number; output: number; cacheRead: number; cacheCreate: number }

--- a/src/stores/sessionStore.ts
+++ b/src/stores/sessionStore.ts
@@ -1,13 +1,14 @@
 /* AgentBro — Session State Management (Zustand) */
 import { create, type StoreApi, type UseBoundStore } from 'zustand'
 import { useConfigStore } from './configStore'
-import type { AgentEvent, BaseLayer, ChatHistoryMeta, ChatMessage, OverlayItem, PanelState, RateLimitInfo, SessionState } from '../types/agent'
+import type { AgentEvent, AgentRunState, BaseLayer, ChatHistoryMeta, ChatMessage, OverlayItem, PanelState, RateLimitInfo, SessionState } from '../types/agent'
 import { OVERLAY_PRIORITY } from '../types/agent'
 import { isQuietHours } from '../utils/quietHours'
 import { isSessionPastDisplayTimeout, timestampToMs } from '../utils/sessionDisplay'
 import { sessionMatchesLegacyCwdExclusion, sessionMatchesSilenceRule } from '../utils/sessionSilence'
 import { isCodexTitleMetadata } from '../utils/codexMetadata'
 import { respondPermission, saveSessions as saveSessionsToBackend } from '../services/tauriApi'
+import { agentRunStateFromSession, runStateForLegacyEvent } from '../utils/agentRunState'
 
 // Debounce helper
 function debounce<T extends (...args: Parameters<T>) => void>(fn: T, ms: number): T {
@@ -757,6 +758,19 @@ export const useSessionStore: UseBoundStore<StoreApi<SessionStore>> = create<Ses
         }
       }
 
+      // Keep the provider-neutral lifecycle state alongside the legacy fields
+      // while adapters continue to emit the existing hook event contract.
+      if (event.type !== 'session_end' && event.sessionId) {
+        const session = sessions[event.sessionId]
+        if (session) {
+          const runState: AgentRunState = event.type === 'permission_request'
+            && session.phase === 'processing'
+            ? agentRunStateFromSession(session)
+            : runStateForLegacyEvent(event, session.runState, session) ?? agentRunStateFromSession(session)
+          sessions[event.sessionId] = { ...session, runState }
+        }
+      }
+
       return { sessions, sessionList: toList(sessions), panelState, activeSessionId, overlayQueue, activeOverlay: overlayQueue[0] ?? null }
     })
     // Trigger debounced save after update
@@ -827,7 +841,7 @@ export const useSessionStore: UseBoundStore<StoreApi<SessionStore>> = create<Ses
           ? 'compacting'
           : basePhase
         const enteredEffectiveIdle = phase === 'idle' && existing?.phase !== 'idle'
-        const s: SessionState = {
+        const baseSession: SessionState = {
           ...incoming,
           phase,
           description: phase === 'compacting'
@@ -868,6 +882,10 @@ export const useSessionStore: UseBoundStore<StoreApi<SessionStore>> = create<Ses
               ?? (enteredDone ? (existing ? now : sessionActivityAnchor(incoming, now)) : undefined)
             : incoming.taskCompletedAt,
           lastActivityAt: incoming.lastActivityAt ?? (activityChanged ? now : existing?.lastActivityAt),
+        }
+        const s: SessionState = {
+          ...baseSession,
+          runState: incoming.runState ?? agentRunStateFromSession(baseSession, now),
         }
         sessions[s.id] = s
         if (isRemoteSession(s) && s.phase === 'processing' && lastUserMessageChanged) {

--- a/src/test/agentRunState.test.ts
+++ b/src/test/agentRunState.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import type { SessionState } from '../types/agent'
+import {
+  agentRunEventFromLegacy,
+  agentRunStateFromSession,
+  applyAgentRunEvent,
+  filterCodexSessions,
+} from '../utils/agentRunState'
+
+function session(overrides: Partial<SessionState> = {}): SessionState {
+  return {
+    id: 's1',
+    agentType: 'codex',
+    project: 'agentbro',
+    terminal: 'Codex',
+    phase: 'processing',
+    startedAt: 1_700_000_000_000,
+    duration: 0,
+    tokens: { input: 0, output: 0, cacheRead: 0, cacheCreate: 0 },
+    chatHistory: [],
+    subagents: [],
+    activeTools: [],
+    ...overrides,
+  }
+}
+
+describe('agent run state normalization', () => {
+  it('maps a Codex tool snapshot to a running state with a current action', () => {
+    const state = agentRunStateFromSession(session({ lastToolName: 'Bash', lastToolTarget: 'pnpm test' }))
+
+    expect(state).toMatchObject({
+      agent: 'codex',
+      sessionId: 's1',
+      status: 'running',
+      phase: 'processing',
+      currentAction: 'Bash: pnpm test',
+    })
+    expect(() => new Date(state.startedAt || '').toISOString()).not.toThrow()
+  })
+
+  it('represents waiting permission, waiting input, errors, and completion', () => {
+    expect(agentRunStateFromSession(session({ phase: 'waiting_approval' })).status).toBe('waiting_permission')
+    expect(agentRunStateFromSession(session({ phase: 'waiting_input' })).status).toBe('waiting_input')
+    expect(agentRunStateFromSession(session({ phase: 'error' })).status).toBe('error')
+    expect(agentRunStateFromSession(session({ phase: 'done' })).status).toBe('completed')
+  })
+
+  it('maps legacy Codex hook events through the unified lifecycle', () => {
+    const event = agentRunEventFromLegacy({
+      type: 'tool_use',
+      sessionId: 's1',
+      toolName: 'Bash',
+      toolInput: '{"command":"pnpm test"}',
+      toolTarget: 'pnpm test',
+      status: 'running',
+    })
+    expect(event).toEqual({ type: 'tool_started', toolName: 'Bash', toolTarget: 'pnpm test' })
+
+    const next = applyAgentRunEvent(agentRunStateFromSession(session()), event!, 1_700_000_001_000)
+    expect(next).toMatchObject({ status: 'running', currentAction: 'Bash: pnpm test' })
+  })
+
+  it('keeps only normalized Codex sessions in the Island', () => {
+    const codex = session({ runState: { ...agentRunStateFromSession(session()), agent: 'codex' } })
+    const claude = session({
+      id: 's2',
+      agentType: 'claude-code',
+      runState: { ...agentRunStateFromSession(session()), agent: 'claude-code', sessionId: 's2' },
+    })
+
+    expect(filterCodexSessions([codex, claude]).map((item) => item.id)).toEqual(['s1'])
+  })
+})
+

--- a/src/test/settingsIslandMenu.test.tsx
+++ b/src/test/settingsIslandMenu.test.tsx
@@ -57,6 +57,10 @@ vi.mock('react-i18next', () => ({
   }),
 }))
 
+vi.mock('../components/settings/sections/AgentMonitorSection', () => ({
+  AgentMonitorSection: () => <section><h2>Tasks</h2></section>,
+}))
+
 describe('settings island menu', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -78,6 +82,43 @@ describe('settings island menu', () => {
     })
   })
 
+  it('shows only the Control Tower primary navigation', () => {
+    const { container } = render(<SettingsApp onClose={vi.fn()} />)
+    const visibleLabels = Array.from(
+      container.querySelectorAll('.settings-sidebar__item:not([hidden]) .settings-sidebar__label-text'),
+    ).map((item) => item.textContent?.trim())
+
+    expect(visibleLabels).toEqual(['Tasks', 'Usage', 'Settings'])
+    expect(screen.getByText('settings.skillManager')).not.toBeVisible()
+    expect(screen.getByText('settings.remoteServers.title')).not.toBeVisible()
+    expect(screen.getByText('settings.island.title')).not.toBeVisible()
+  })
+
+  it('switches between Tasks, Usage, and Settings', async () => {
+    render(<SettingsApp onClose={vi.fn()} />)
+
+    expect(screen.getByRole('heading', { name: 'Tasks' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Usage' }))
+    expect(await screen.findByRole('heading', { name: 'Usage' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Settings' }))
+    await waitFor(() => expect(screen.getByText('settings.language')).toBeInTheDocument())
+  })
+
+  it('keeps first-run analytics consent without exposing Pet choices', async () => {
+    useConfigStore.setState({
+      analyticsEnabled: false,
+      analyticsConsentPromptCompleted: false,
+    })
+    render(<SettingsApp onClose={vi.fn()} />)
+
+    expect(screen.queryByRole('radio', { name: /settings.surfacePet/ })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'settings.welcomeContinue' }))
+
+    await waitFor(() => expect(useConfigStore.getState().analyticsConsentPromptCompleted).toBe(true))
+    expect(useConfigStore.getState().analyticsEnabled).toBe(true)
+    expect(tauriMocks.setAnalyticsEnabled).toHaveBeenCalledWith(true)
+  })
+
   it('uses the left settings menu for island pages instead of top tabs', async () => {
     const { container } = render(<SettingsApp onClose={vi.fn()} />)
 
@@ -95,29 +136,6 @@ describe('settings island menu', () => {
     expect(screen.getByRole('radiogroup', { name: '展示模式' })).toBeInTheDocument()
     expect(screen.getByRole('radio', { name: '灵动岛' })).toHaveAttribute('aria-checked', 'true')
     expect(container.querySelector('.island-tabs')).not.toBeInTheDocument()
-  })
-
-  it('completes first-run setup with surface mode and default analytics enabled', async () => {
-    useConfigStore.setState({
-      analyticsEnabled: false,
-      analyticsConsentPromptCompleted: false,
-      islandSurfaceMode: 'island',
-      islandPetWindowOrigin: { x: 12, y: 18 },
-    })
-    render(<SettingsApp onClose={vi.fn()} />)
-
-    fireEvent.click(screen.getByRole('radio', { name: /settings.surfacePet/ }))
-    fireEvent.click(screen.getByRole('button', { name: 'settings.welcomeContinue' }))
-
-    await waitFor(() => expect(useConfigStore.getState().analyticsConsentPromptCompleted).toBe(true))
-    expect(useConfigStore.getState().analyticsEnabled).toBe(true)
-    expect(useConfigStore.getState().islandSurfaceMode).toBe('pet')
-    expect(useConfigStore.getState().islandPetWindowOrigin).toBe(null)
-    expect(tauriMocks.setIslandSurfaceOptions).toHaveBeenCalledWith({
-      islandSurfaceMode: 'pet',
-      islandPetScale: 72,
-    })
-    expect(tauriMocks.setAnalyticsEnabled).toHaveBeenCalledWith(true)
   })
 
   it('keeps SSH server management out of the Dynamic Island menu', async () => {

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -12,6 +12,45 @@ export type AgentType =
 
 export type ToolStatus = 'running' | 'success' | 'error' | 'interrupted'
 
+/** Provider-neutral lifecycle status used by the Island and Agent Monitor. */
+export type AgentRunStatus =
+  | 'idle'
+  | 'starting'
+  | 'running'
+  | 'waiting_input'
+  | 'waiting_permission'
+  | 'blocked'
+  | 'rate_limited'
+  | 'error'
+  | 'completed'
+  | 'cancelled'
+  | 'unknown'
+
+export interface AgentRunState {
+  agent: string
+  sessionId?: string
+  status: AgentRunStatus
+  phase?: string
+  currentAction?: string
+  startedAt?: string
+  updatedAt: string
+}
+
+/** Normalized lifecycle events consumed by views instead of provider payloads. */
+export type AgentRunEvent =
+  | { type: 'session_started'; agent: string; sessionId: string; startedAt?: string }
+  | { type: 'status_changed'; status: AgentRunStatus; phase?: string; currentAction?: string }
+  | { type: 'tool_started'; toolName: string; toolTarget?: string }
+  | { type: 'tool_finished'; toolName: string; toolTarget?: string; status: Extract<ToolStatus, 'success' | 'error' | 'interrupted'> }
+  | { type: 'waiting_input'; question?: string }
+  | { type: 'permission_requested'; toolName?: string }
+  | { type: 'rate_limited'; phase?: string; currentAction?: string }
+  | { type: 'error'; message?: string }
+  | { type: 'completed'; summary?: string }
+  | { type: 'usage_updated' }
+
+export type UnifiedAgentEvent = AgentRunEvent
+
 export type SessionPhase =
   | 'ready'
   | 'idle'
@@ -167,6 +206,8 @@ export interface SessionState {
   cwd?: string
   terminal: string
   phase: SessionPhase
+  /** Normalized lifecycle state; legacy phase remains for compatibility. */
+  runState?: AgentRunState
   startedAt: number
   idleSince?: number
   unattendedSince?: number // timestamp when session entered a waiting state

--- a/src/types/priority.ts
+++ b/src/types/priority.ts
@@ -17,9 +17,27 @@ export type PriorityName = keyof typeof PRIORITY
 export function computePriority(session: {
   phase: string
   lastToolName?: string
+  runState?: {
+    status: string
+    currentAction?: string
+    phase?: string
+  }
   idleSince?: number
   startedAt: number
 }): Priority {
+  const runStatus = session.runState?.status
+  if (runStatus === 'error') return PRIORITY.error
+  if (runStatus === 'waiting_permission' || runStatus === 'waiting_input' || runStatus === 'blocked') {
+    return PRIORITY.attention
+  }
+  if (runStatus === 'rate_limited') return PRIORITY.attention
+  if (runStatus === 'running') {
+    return session.runState?.currentAction || session.lastToolName ? PRIORITY.working : PRIORITY.thinking
+  }
+  if (runStatus === 'starting') return PRIORITY.thinking
+  if (runStatus === 'completed') return PRIORITY.done
+  if (runStatus === 'cancelled') return PRIORITY.done
+
   if (session.phase === 'error') return PRIORITY.error
   if (session.phase === 'waiting_approval' || session.phase === 'waiting_input')
     return PRIORITY.attention

--- a/src/utils/agentRunState.ts
+++ b/src/utils/agentRunState.ts
@@ -1,0 +1,168 @@
+import type { AgentEvent, AgentRunEvent, AgentRunState, AgentRunStatus, SessionState, ToolStatus } from '../types/agent'
+
+const TERMINAL_TOOL_STATUSES = new Set<Extract<ToolStatus, 'success' | 'error' | 'interrupted'>>([
+  'success',
+  'error',
+  'interrupted',
+])
+
+function epochMs(value: number | undefined): number | undefined {
+  if (value == null || !Number.isFinite(value)) return undefined
+  return value < 1_000_000_000_000 ? value * 1000 : value
+}
+
+function isoTimestamp(value: number | undefined, fallback = Date.now()): string {
+  return new Date(epochMs(value) ?? fallback).toISOString()
+}
+
+function actionLabel(toolName?: string, toolTarget?: string): string | undefined {
+  if (!toolName) return undefined
+  return toolTarget ? `${toolName}: ${toolTarget}` : toolName
+}
+
+export function statusFromSession(session: Pick<SessionState, 'phase' | 'pendingPermission' | 'pendingQuestion' | 'planTitle' | 'planContent'>): AgentRunStatus {
+  if (session.pendingPermission || session.planTitle || session.planContent || session.phase === 'waiting_approval') {
+    return 'waiting_permission'
+  }
+  if (session.pendingQuestion || session.phase === 'waiting_input') return 'waiting_input'
+  if (session.phase === 'processing' || session.phase === 'compacting') return 'running'
+  if (session.phase === 'error') return 'error'
+  if (session.phase === 'done') return 'completed'
+  if (session.phase === 'interrupted') return 'cancelled'
+  if (session.phase === 'ready' || session.phase === 'idle') return 'idle'
+  return 'unknown'
+}
+
+export function agentRunStateFromSession(session: SessionState, now = Date.now()): AgentRunState {
+  const currentAction = actionLabel(session.lastToolName, session.lastToolTarget)
+    || session.description
+    || undefined
+  const activityAt = session.lastActivityAt
+    ?? session.taskCompletedAt
+    ?? session.lastMainAgentAt
+    ?? session.startedAt
+
+  return {
+    agent: session.agentType,
+    sessionId: session.id,
+    status: statusFromSession(session),
+    phase: session.phase,
+    currentAction,
+    startedAt: isoTimestamp(session.startedAt, now),
+    updatedAt: isoTimestamp(activityAt, now),
+  }
+}
+
+export function agentRunEventFromLegacy(event: AgentEvent): AgentRunEvent | undefined {
+  switch (event.type) {
+    case 'session_start':
+      return { type: 'session_started', agent: event.agentType, sessionId: event.sessionId }
+    case 'processing':
+      return { type: 'status_changed', status: 'running', phase: 'processing', currentAction: event.description }
+    case 'user_message':
+      return { type: 'status_changed', status: 'running', phase: 'processing', currentAction: event.content }
+    case 'tool_use':
+      return TERMINAL_TOOL_STATUSES.has(event.status as Extract<ToolStatus, 'success' | 'error' | 'interrupted'>)
+        ? { type: 'tool_finished', toolName: event.toolName, toolTarget: event.toolTarget, status: event.status as Extract<ToolStatus, 'success' | 'error' | 'interrupted'> }
+        : { type: 'tool_started', toolName: event.toolName, toolTarget: event.toolTarget }
+    case 'permission_request':
+      return { type: 'permission_requested', toolName: event.toolName }
+    case 'ask_question':
+      return { type: 'waiting_input', question: event.question }
+    case 'plan_request':
+      return { type: 'permission_requested' }
+    case 'task_complete':
+      return { type: 'completed', summary: event.summary }
+    case 'error':
+      return { type: 'error', message: event.message }
+    case 'interrupt':
+      return { type: 'status_changed', status: 'cancelled', phase: 'interrupted' }
+    case 'context_compact':
+      return event.phase === 'pre'
+        ? { type: 'status_changed', status: 'running', phase: 'compacting', currentAction: 'Compacting context' }
+        : { type: 'status_changed', status: 'running', phase: 'processing' }
+    case 'token_usage':
+      return { type: 'usage_updated' }
+    default:
+      return undefined
+  }
+}
+
+export function applyAgentRunEvent(
+  previous: AgentRunState,
+  event: AgentRunEvent,
+  now = Date.now(),
+): AgentRunState {
+  const updatedAt = new Date(now).toISOString()
+  switch (event.type) {
+    case 'session_started':
+      return {
+        ...previous,
+        agent: event.agent,
+        sessionId: event.sessionId,
+        status: 'starting',
+        phase: 'ready',
+        currentAction: undefined,
+        startedAt: event.startedAt ?? updatedAt,
+        updatedAt,
+      }
+    case 'status_changed':
+      return {
+        ...previous,
+        status: event.status,
+        phase: event.phase ?? previous.phase,
+        currentAction: event.currentAction ?? previous.currentAction,
+        updatedAt,
+      }
+    case 'tool_started':
+      return {
+        ...previous,
+        status: 'running',
+        phase: 'processing',
+        currentAction: actionLabel(event.toolName, event.toolTarget),
+        updatedAt,
+      }
+    case 'tool_finished':
+      return {
+        ...previous,
+        status: event.status === 'error' ? 'error' : event.status === 'interrupted' ? 'cancelled' : 'running',
+        phase: event.status === 'error' ? 'error' : event.status === 'interrupted' ? 'interrupted' : 'processing',
+        currentAction: actionLabel(event.toolName, event.toolTarget),
+        updatedAt,
+      }
+    case 'waiting_input':
+      return { ...previous, status: 'waiting_input', phase: 'waiting_input', currentAction: event.question, updatedAt }
+    case 'permission_requested':
+      return { ...previous, status: 'waiting_permission', phase: 'waiting_approval', currentAction: event.toolName, updatedAt }
+    case 'rate_limited':
+      return { ...previous, status: 'rate_limited', phase: event.phase ?? previous.phase, currentAction: event.currentAction ?? previous.currentAction, updatedAt }
+    case 'error':
+      return { ...previous, status: 'error', phase: 'error', currentAction: event.message, updatedAt }
+    case 'completed':
+      return { ...previous, status: 'completed', phase: 'done', currentAction: event.summary, updatedAt }
+    case 'usage_updated':
+      return { ...previous, updatedAt }
+  }
+}
+
+export function runStateForLegacyEvent(
+  event: AgentEvent,
+  previous: AgentRunState | undefined,
+  session?: SessionState,
+  now = Date.now(),
+): AgentRunState | undefined {
+  const normalized = agentRunEventFromLegacy(event)
+  if (!normalized) return session ? agentRunStateFromSession(session, now) : previous
+  const base = previous
+    ?? (session ? agentRunStateFromSession(session, now) : {
+      agent: 'unknown',
+      sessionId: 'sessionId' in event ? event.sessionId : undefined,
+      status: 'unknown' as const,
+      updatedAt: new Date(now).toISOString(),
+    })
+  return applyAgentRunEvent(base, normalized, now)
+}
+
+export function filterCodexSessions(sessions: SessionState[]): SessionState[] {
+  return sessions.filter((session) => (session.runState?.agent ?? session.agentType) === 'codex')
+}

--- a/src/utils/islandInteraction.ts
+++ b/src/utils/islandInteraction.ts
@@ -1,4 +1,5 @@
 import type { OverlayItem, PanelState, SessionState } from '../types/agent'
+import { statusFromSession } from './agentRunState'
 
 export type IslandOuterState = 'hidden' | 'micro' | 'compact' | 'expanded'
 export type IslandInteractionMode = 'persistent' | 'minimal'
@@ -43,11 +44,18 @@ export function isRemoteSession(session: SessionState): boolean {
 }
 
 export function sessionHasVisibleActivity(session: SessionState): boolean {
-  return !isRemoteSession(session) && (session.phase === 'processing' || session.phase === 'compacting')
+  if (isRemoteSession(session)) return false
+  return session.runState
+    ? session.runState.status === 'running'
+    : session.phase === 'processing' || session.phase === 'compacting'
 }
 
 export function sessionNeedsAttention(session: SessionState): boolean {
-  return session.phase === 'waiting_approval'
+  const status = session.runState?.status ?? statusFromSession(session)
+  return status === 'waiting_permission'
+    || status === 'waiting_input'
+    || status === 'error'
+    || session.phase === 'waiting_approval'
     || session.phase === 'waiting_input'
     || session.phase === 'error'
     || Boolean(session.pendingPermission)


### PR DESCRIPTION
## Summary
- add provider-neutral AgentRunState and lifecycle event normalization
- expose normalized state in backend session snapshots and frontend stores
- use normalized state for Codex Island display while preserving legacy snapshots
- add lifecycle and serialization coverage

Closes #104